### PR TITLE
Drive deity scripts from centrally defined constants

### DIFF
--- a/deploy/cron/deity_fiveminute.php
+++ b/deploy/cron/deity_fiveminute.php
@@ -30,8 +30,8 @@ DatabaseConnection::$pdo->query('COMMIT');
 
 // Err on the side of low revives for this five minute tick.
 $params = [
-	'minor_revive_to'      => MINOR_REVIVE_THRESHOLDMAJOR_REVIVE_PERCENT,
-	'major_revive_percent' => MINOR_REVIVE_THRESHOLDMAJOR_REVIVE_PERCENT
+	'minor_revive_to'      => MINOR_REVIVE_THRESHOLD,
+	'major_revive_percent' => MAJOR_REVIVE_PERCENT,
 ];
 
 $resurrected = revive_players($params);

--- a/deploy/cron/deity_halfhour.php
+++ b/deploy/cron/deity_halfhour.php
@@ -9,10 +9,6 @@ require_once(LIB_ROOT."control/lib_deity.php"); // Deity-specific functions
 
 $logMessage = "DEITY_HALFHOUR STARTING: ".date(DATE_RFC1036)."\n";
 
-$regen_rate           = 2; // Rate is for turns.
-$turn_regen_threshold = 100;
-$maximum_heal         = 200;
-$maxtime              = '70 hours'; // *** Max time a person is kept online without being active.
 $score                = get_score_formula();
 
 DatabaseConnection::getInstance();
@@ -20,14 +16,14 @@ DatabaseConnection::$pdo->query('BEGIN TRANSACTION');
 DatabaseConnection::$pdo->query("UPDATE players SET turns = 0 WHERE turns < 0"); // if anyone has less than 0 turns, set it to 0
 
 $s = DatabaseConnection::$pdo->prepare("UPDATE players SET turns = turns+:rate WHERE turns < :threshold");  // add turns at the regen rate for anyone below the threshold
-$s->bindValue(':rate', $regen_rate);
-$s->bindValue(':threshold', $turn_regen_threshold);
+$s->bindValue(':rate', TURN_REGEN_PER_TICK);
+$s->bindValue(':threshold', TURN_REGEN_THRESHOLD);
 $s->execute();
 
 DatabaseConnection::$pdo->query("UPDATE players SET bounty = 0 WHERE bounty < 0"); // if anyone has negative bounty, set it to 0
 
 $inactivity = DatabaseConnection::$pdo->prepare("DELETE FROM ppl_online WHERE activity < (now() - :maxtime::interval)");
-$inactivity->bindValue(':maxtime', $maxtime);
+$inactivity->bindValue(':maxtime', ONLINE_TIMEOUT);
 $inactivity->execute();
 
 $out_display['Inactive Browsers Deactivated'] = $inactivity->rowCount();

--- a/deploy/cron/deity_hourly.php
+++ b/deploy/cron/deity_hourly.php
@@ -14,13 +14,6 @@ $score = get_score_formula();
 // Note that this script should not be web-accessible.
 DatabaseConnection::getInstance();
 
-// ******************* INITIALIZATION ******************************
-$poisonHealthDecrease = 50;			// *** The amount that poison decreases health each half-hour.
-$maximum_heal         = 200;
-$maximum_turns        = 300;		// *** Turn # beyond which you will drop back down to, though normal turn increase stops earlier.
-$maxtime              = '6 hours';	// *** Max time a person is kept online without being active.
-$turn_regen_threshold = 100;
-
 $out_display = array();
 
 // ******************* END OF CONSTANTS ***********************
@@ -31,62 +24,38 @@ DatabaseConnection::$pdo->query("UPDATE time SET amount = 0 WHERE time_label = '
 DatabaseConnection::$pdo->query("UPDATE players SET turns = 0 WHERE turns < 0");
 DatabaseConnection::$pdo->query("UPDATE players SET bounty = 0 WHERE bounty < 0");
 $s = DatabaseConnection::$pdo->prepare("UPDATE players SET turns = turns+1 FROM class_skill JOIN skill ON skill_id = _skill_id WHERE turns < :threshold AND _skill_id = 3 AND class_skill._class_id = players._class_id AND level >= coalesce(class_skill_level, skill_level)");	// *** Speed skill turn gain code, replaces Blue/Crane turn gain code ***
-$s->bindValue(':threshold', $turn_regen_threshold);
+$s->bindValue(':threshold', TURN_REGEN_THRESHOLD);
 $s->execute();
 
-//DatabaseConnection::$pdo->query("UPDATE players SET turns = turns+1 WHERE _class_id = 2 AND turns < ".$turn_regen_threshold); // Blue/Crane turn code
-$s = DatabaseConnection::$pdo->prepare("UPDATE players SET turns = turns+2 WHERE turns < :threshold"); // add 2 turns on the hour, up to 100.
-$s->bindValue(':threshold', $turn_regen_threshold);
+$s = DatabaseConnection::$pdo->prepare("UPDATE players SET turns = turns+:regen_rate WHERE turns < :threshold"); // add 2 turns on the hour, up to 100.
+$s->bindValue(':threshold', TURN_REGEN_THRESHOLD);
+$s->bindValue(':regen_rate', TURN_REGEN_PER_TICK);
 $s->execute();
-
-//In activity is being handled by half-hourly right now, no need to run this query in both scripts.
-//$inactivity = DatabaseConnection::$pdo->query("DELETE FROM ppl_online WHERE activity < (now() - interval '".$maxtime."')");
 
 //Skip error logging this for now. $out_display['Inactive Browsers Deactivated'] = $inactivity->rowCount();
 
 // *** HEAL ***
 $s = DatabaseConnection::$pdo->prepare(
-	"UPDATE players SET health = numeric_smaller(health+8, :max_heal) ".
+	"UPDATE players SET health = numeric_smaller(health+:regen_rate, :max_heal) ".
 	     "WHERE health BETWEEN 1 AND :max_heal2 AND NOT ".
 		 "CAST(status&:poison AS boolean)"
 );
-$s->bindValue(':max_heal', $maximum_heal);
-$s->bindValue(':max_heal2', $maximum_heal);
+$s->bindValue(':max_heal', HEALTH_REGEN_THRESHOLD);
+$s->bindValue(':max_heal2', HEALTH_REGEN_THRESHOLD);
+$s->bindValue(':regen_rate', HEALTH_REGEN_PER_TICK);
 $s->bindValue(':poison', POISON);
 $s->execute();
 
-// ****************************** RESURRECTION CHECK, DEPENDENT UPON RESURRECTION_TIME ****************************
-/* OLD System
-$minimum = 2;
-$by_percent = true;
-$maximum = 4;
-
-$resurrect_info = revive_appropriate_players($minimum, $maximum, $by_percent, $just_testing=false);
-assert($resurrect_info['revived']<$resurrect_info['target_number']);
-*/
-// New system, potentially move to the halfhour, and then half the major_revive_percent?
-//$params = array('full_max'=>75, 'minor_revive_to'=>300, 'major_revive_percent'=>15);
-//$resurrected = revive_players($params);
-/* @params array('full_max'=>80, 'minor_revive_to'=>100, 'major_revive_percent'=>5,
- *      'just_testing'=>false)
-*/
-// $out_display['Players Resurrected'] = reset($resurrected);
-// $out_display['Total Dead'] = end($resurrected);
-
-// Ranking gets done in the 5 minute one now, so no need for it here.
-// ***********************
-
-// previously: CASE WHEN health-10 < 0 THEN health*(-1) ELSE 10 END
 assert(POISON != 'POISON');
 $s = DatabaseConnection::$pdo->prepare("UPDATE players SET health = numeric_larger(0, health-:damage) WHERE health > 0 AND CAST((status&:poison) AS bool)"); // *** poisoned takes away life ***
-$s->bindValue(':damage', $poisonHealthDecrease);
+$s->bindValue(':damage', POISON_DAMAGE);
 $s->bindValue(':poison', POISON);
 $s->execute();
 
 DatabaseConnection::$pdo->query("UPDATE players SET health = 0 WHERE health < 0"); // *** zeros negative health totals.
 $s = DatabaseConnection::$pdo->prepare("UPDATE players SET turns = :max_turns WHERE turns > :max_turns2"); // max turn limiter gets run from the constants section.
-$s->bindValue(':max_turns', $maximum_turns);
-$s->bindValue(':max_turns2', $maximum_turns);
+$s->bindValue(':max_turns', MAX_TURNS);
+$s->bindValue(':max_turns2', MAX_TURNS);
 $s->execute();
 
 assert(FROZEN != 'FROZEN'); // These constants should be numeric.

--- a/deploy/cron/deity_nightly.php
+++ b/deploy/cron/deity_nightly.php
@@ -20,9 +20,9 @@ $logMessage = "DEITY_NIGHTLY STARTING: ---- ".date(DATE_RFC1036)." ----\n";
 // TODO: When the message table is created, delete from mail more stringently.
 // TODO: Set up a backup of the players table.
 
-$keep_players_until_over_the_number                   = 1000;
-$days_players_have_to_be_older_than_to_be_unconfirmed = 60;
-$maximum_players_to_unconfirm                         = 200;
+$keep_players_until_over_the_number                   = MIN_PLAYERS_FOR_UNCONFIRM;
+$days_players_have_to_be_older_than_to_be_unconfirmed = MIN_DAYS_FOR_UNCONFIRM;
+$maximum_players_to_unconfirm                         = MAX_PLAYERS_TO_UNCONFIRM;
 
 // *************** DEITY NIGHTLY, manual-run-output occurs at the bottom.*********************
 
@@ -64,7 +64,7 @@ $affected_rows['dueling log deletion'] = $duel_log_delete->rowCount();
 
 $level_1_delete = DatabaseConnection::$pdo->query("delete from players where active = 0 and level = 1 and created_date < (now() - interval '5 days')"); // Delete old level 1's.
 DatabaseConnection::$pdo->query('COMMIT');
-$affected_rows['old level 1 players deletion'] = $level_1_delete->rowCount(); 
+$affected_rows['old level 1 players deletion'] = $level_1_delete->rowCount();
 
 
 $logMessage .= "DEITY_NIGHTLY: Deity reset occurred at server date/time: ".date('l jS \of F Y h:i:s A').".\n";

--- a/deploy/derived_constants.php
+++ b/deploy/derived_constants.php
@@ -34,3 +34,25 @@ define('MAX_PLAYER_LEVEL', 350);
 // Defines for avatar options.
 define('GRAVATAR', 1);
 
+// Constants for deity scripts
+define('MIN_PLAYERS_FOR_UNCONFIRM', 1000);
+define('MIN_DAYS_FOR_UNCONFIRM',    60);
+define('MAX_PLAYERS_TO_UNCONFIRM',  200);
+define('POISON_DAMAGE',             50);
+define('MAX_TURNS',                 300); // Turn # beyond which you will drop back down to, though normal turn increase stops earlier.
+define('ONLINE_TIMEOUT',            '70 hours'); // Max time a person is kept online without being active.
+define('TURN_REGEN_PER_TICK',       2);
+define('TURN_REGEN_THRESHOLD',      100);
+define('HEALTH_REGEN_THRESHOLD',    200);
+define('HEALTH_REGEN_PER_TICK',     8);
+define('KI_REGEN_PER_TICK',         1);
+define('KI_REGEN_TIMEOUT',          '6 minutes');
+
+define('MINOR_REVIVE_THRESHOLD',    70);
+define('MAJOR_REVIVE_PERCENT',      7);
+
+define('DEITY_LOG_CHANCE_DIVISOR',  60);
+
+define('RANK_WEIGHT_LEVEL',      5000);
+define('RANK_WEIGHT_GOLD',       200);
+define('RANK_WEIGHT_INACTIVITY', 200);

--- a/deploy/lib/control/lib_deity.php
+++ b/deploy/lib/control/lib_deity.php
@@ -44,7 +44,6 @@ function unconfirm_older_players_over_minimums($keep_players=2300, $unconfirm_da
 	$change_confirm_to = ($just_testing ? '1' : '0'); // Only unconfirm players when not testing.
 	$minimum_days = 30;
 	$max_to_unconfirm = (is_numeric($max_to_unconfirm) ? $max_to_unconfirm : 30);
-	$players_unconfirmed = null;
 	DatabaseConnection::getInstance();
 	$sel_cur = DatabaseConnection::$pdo->query("SELECT count(*) FROM players WHERE active = 1");
 	$current_players = $sel_cur->fetchColumn();
@@ -115,13 +114,12 @@ function heal_characters($basic=8, $with_level=true, $maximum_heal='200'){
  * Revive up to a small max in minor hours, and a stable percent on major hours.
  * Defaults
  * sample_use: revive_players(array('just_testing'=>true));
- * @params array('full_max'=>80, 'minor_revive_to'=>100, 'major_revive_percent'=>5,
+ * @params array('minor_revive_to'=>100, 'major_revive_percent'=>5,
  *      'just_testing'=>false)
 **/
 function revive_players($params=array()) {
 	// Previous min/max was 2-4% always, ~3000 players, so 60-120 each time.
 
-	$full_max             = (isset($params['full_max']) ? $params['full_max'] : 80); // In: full_max, default 80%
 	$minor_revive_to      = (isset($params['minor_revive_to']) ? $params['minor_revive_to'] : 100); // minor_revive_to, default 100
 	$major_revive_percent = (isset($params['major_revive_percent']) ? $params['major_revive_percent'] : 5); // major_revive_percent, default 5%
 	$just_testing         = isset($params['just_testing']);
@@ -180,7 +178,7 @@ function revive_players($params=array()) {
 			$revive_amount = $percent_int;
 		}
 	}
-	//die();
+
 	assert(isset($revive_amount));
 	assert(isset($current_time));
 	assert(isset($just_testing));
@@ -199,7 +197,7 @@ function revive_players($params=array()) {
 							CASE WHEN level >= coalesce(class_skill_level, skill_level)
 							THEN (150+(level*3))
 							ELSE (100+(level*3)) END
-							FROM (SELECT * FROM skill LEFT JOIN class_skill ON skill_id = _skill_id WHERE skill_id = 5) 
+							FROM (SELECT * FROM skill LEFT JOIN class_skill ON skill_id = _skill_id WHERE skill_id = 5)
 								AS class_skill ';
 							// Midnight heal skill id is the 5.
 	}


### PR DESCRIPTION
resolve #220
Added constants to derived_constants.php for now. They can be moved
easily later. Add additional parameters for Ki regeneration and some of
the necessary parameters for ranking. Ranking still needs more work to
be fully parameterized though.