### PR TITLE
Allow players to level to the max level

### DIFF
--- a/deploy/lib/control/lib_player.php
+++ b/deploy/lib/control/lib_player.php
@@ -124,7 +124,7 @@ function level_up_if_possible($char_id, $auto_level=false) {
 			$required_kills = required_kills_to_level($char_level);
 			// Have to be under the max level and have enough kills.
 			$level_up_possible = (
-				($nextLevel < $max_level) &&
+				($nextLevel <= $max_level) &&
 				($char_kills >= $required_kills) );
 
 			if ($level_up_possible) {

--- a/deploy/templates/dojo.tpl
+++ b/deploy/templates/dojo.tpl
@@ -134,7 +134,9 @@ table .char-title td{
 
 <p>Your current class is <span class='class-name {$possibly_changed_class_theme}'>{$possibly_changed_class_name|escape}</span>.</p>
 <p>Your current level is {$userLevel|escape}. Your current kills are {$userKills|escape}.</p>
+{if $userLevel < $max_level}
 <p>Level {$nextLevel|escape} requires {$required_kills|escape} kills.</p>
+{/if}
 
 	{if $upgrade_requested}
 		{if $userLevel+1 > $max_level}

--- a/deploy/www/dojo.php
+++ b/deploy/www/dojo.php
@@ -147,7 +147,7 @@ function dim_mak_reqs($char_obj, $turn_req, $str_req){
 	    $char_data = $char->data();
 	    
 	    // Get the info for the next level, especially if that has changed.
-	    $nextLevel = $userLevel+1;
+	    $nextLevel = min($userLevel+1, $max_level);
 	    $userKills = char_kills($char_id);
     	$required_kills = required_kills_to_level($userLevel);
 	}


### PR DESCRIPTION
resolve #140 

A simple off-by-one error cause by a less-than instead of
less-than-or-equal. Also added a conditional to the dojo template to
hide the "next level" message when upgrading to the max level.