### PR TITLE
Fix message display when using items on target

### DIFF
--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -322,7 +322,7 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 			$attacker_id = $username;
 		}
 
-		if (!$self_use) {
+		if (!$self_use && $item_used) {
 			if (!$targetResult) {
 				error_log('Debug: Issue 226 - An attack was made using '.$item->getName().', but no targetResult message was set.');
 			}

--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -7,8 +7,8 @@ require_once(LIB_ROOT."control/lib_inventory.php");
  * @subpackage skill
  */
 
-$private    = true;
-$alive      = true;
+$private = true;
+$alive   = true;
 
 if ($error = init($private, $alive)) {
 	display_error($error);
@@ -16,24 +16,49 @@ if ($error = init($private, $alive)) {
 } else {
 
 $link_back  = in('link_back');
-$in_target_id  = in('target_id');
-$target_id = $in_target_id? (int) $in_target_id : self_char_id();
-$target     = first_value($target_id, in('target'));
 $selfTarget = in('selfTarget');
-
-// *** Item identifier, either it's id or internal name ***
-$item_in = in('item');
-
+$item_in    = in('item'); // Item identifier, either it's id or internal name
 $give       = in('give');
-$give       = in_array($give, array('on', 'Give'));
 $target_id  = in('target_id');
+$in_target  = in('target');
 
-$item = null;
+///TODO clean up this travesty
+$target_id = ($target_id ? (int) $target_id : self_char_id());
+$target    = first_value($target_id, $in_target);
+$target_id = whichever($target_id, get_char_id($target));
+
+$give      = in_array($give, array('on', 'Give'));
+
+$user_id   = self_char_id();
+$player    = new Player($user_id);
+
+$victim_alive           = true;
+$using_item             = true;
+$item_used              = true;
+$stealthLost            = false;
+$error                  = false;
+$suicide                = false;
+$kill                   = false;
+$repeat                 = false;
+$ending_turns           = null;
+$turns_change           = null;
+$turns_to_take          = null;
+$gold_mod               = NULL;
+$result                 = NULL;
+$targetResult           = NULL; // result message to send to target of item use
+$targetName             = '';
+$targetHealth           = '';
+$targetHealthPercent    = '';
+$bountyMessage          = '';
+$resultMessage          = '';
+$alternateResultMessage = '';
 
 if ($item_in == (int) $item_in && is_numeric($item_in)) { // Can be cast to an id.
 	$item = $item_obj = getItemByID($item_in);
 } elseif (is_string($item_in)) {
 	$item = $item_obj = getItemByIdentity($item_in);
+} else {
+	$item = null;
 }
 
 if (!is_object($item)) {
@@ -41,34 +66,24 @@ if (!is_object($item)) {
 	redirect(WEB_ROOT.'inventory.php?error=noitem');
 }
 
-$user_id    = self_char_id();
-$player     = new Player($user_id);
-
-$victim_alive   = true;
-$using_item     = true;
-$starting_turns = $player->vo->turns;
-$username_turns = $starting_turns;
-$username_level = $player->vo->level;
-$ending_turns   = null;
-$item_used      = true;
-$turns_change   = null;
-
-// Check whether use on self is occurring.
-$self_use = $selfTarget || $target_id == $user_id;
-
-$target_id = whichever($target_id, get_char_id($target));
-
 $item_count = item_count($user_id, $item);
 
+// Check whether use on self is occurring.
+$self_use = ($selfTarget || ($target_id === $user_id));
+
 if ($self_use) {
-	$target = $username;
+	$target    = $username;
 	$targetObj = $player;
 } else if ($target_id) {
 	$targetObj = new Player($target_id);
-	$target = $targetObj->name();
+	$target    = $targetObj->name();
 
 	set_setting("last_item_used", $item_in); // Save last item used.
 }
+
+$starting_turns = $player->vo->turns;
+$username_turns = $starting_turns;
+$username_level = $player->vo->level;
 
 if (($targetObj instanceof Player) && $targetObj->id()) {
 	$targets_turns = $targetObj->vo->turns;
@@ -80,25 +95,10 @@ if (($targetObj instanceof Player) && $targetObj->id()) {
 	$target_hp     = null;
 }
 
-$targetName = '';
-$targetHealth = '';
-$targetHealthPercent = '';
-
-$gold_mod		= NULL;
-$result			= NULL;
-$targetResult   = NULL; // result message to send to target of item use
-
 $max_power_increase        = 10;
 $level_difference          = $targets_level - $username_level;
 $level_check               = $username_level - $targets_level;
 $near_level_power_increase = nearLevelPowerIncrease($level_difference, $max_power_increase);
-
-$turns_to_take = null;   // *** Take at least one turn away even on failure.
-
-if ($give) {
-	$turn_cost  = 0;
-	$using_item = false;
-}
 
 // Sets the page to link back to.
 if ($target_id && ($link_back == "" || $link_back == 'player') && $target_id != $user_id) {
@@ -106,13 +106,6 @@ if ($target_id && ($link_back == "" || $link_back == 'player') && $target_id != 
 } else {
 	$return_to = 'inventory';
 }
-
-//$dimMak = $speedScroll = $iceScroll = $fireScroll = $shuriken = $stealthScroll = $kampoFormula = $strangeHerb = null;
-
-/*
-Use this sql to see item damage and effects:
-select item_display_name, target_damage, effects.* from item left join item_effects on item_id = _item_id join effects on effect_id = _effect_id;
-*/
 
 // Exceptions to the rules, using effects.
 
@@ -153,14 +146,17 @@ $itemType = $item->getType();
 
 $article = get_indefinite_article($item_obj->getName());
 
-if ($using_item) {
-	$turn_cost = $item->getTurnCost();
+if ($give) {
+	$turn_cost  = 0;
+	$using_item = false;
+} else {
+	$turn_cost  = $item->getTurnCost();
 }
 
 // Attack Legal section
 $attacker = $username;
 
-$params   = [
+$params = [
 	'required_turns'  => $turn_cost,
 	'ignores_stealth' => $item_obj->ignoresStealth(),
 	'self_use'        => $item->isSelfUsable(),
@@ -171,219 +167,188 @@ assert(!!$selfTarget || $attacker != $target);
 $AttackLegal    = new AttackLegal($attacker, $target, $params);
 $attack_allowed = $AttackLegal->check();
 $attack_error   = $AttackLegal->getError();
-$bountyMessage = $resultMessage = $alternateResultMessage = '';
-$error = false;
-$suicide = $kill = $repeat = false;
 
 // *** Any ERRORS prevent attacks happen here  ***
 if (!$attack_allowed) { //Checks for error conditions before starting.
 	$error = 1;
+} else if (is_string($item) || $target == "")  {
+	$error = 2;
+} else if ($item_count < 1) {
+	$error = 3;
 } else {
-	if (is_string($item) || $target == "")  {
-		$error = 2;
+	/**** MAIN SUCCESSFUL USE ****/
+	if ($give) {
+		give_item($username, $target, $item->getName());
+		$alternateResultMessage = "__TARGET__ will receive your {$item->getName()}.";
+	} else if (!$item->isOtherUsable()) {
+		// If it doesn't do damage or have an effect, don't use up the item.
+		$result    = 'This item is not usable on __TARGET__, so it remains unused.';
+		$item_used = false;
 	} else {
-		if ($item_count < 1) {
-			$error = 3;
-		} else {
-			/**** MAIN SUCCESSFUL USE ****/
-			if ($give) {
-				give_item($username, $target, $item->getName());
-				$alternateResultMessage = "__TARGET__ will receive your {$item->getName()}.";
+		// TODO: These result messages are screwed up (e.g. what gets sent to the events mail is wrongly phrased frequently now), and need to be reworked.
+
+		if ($item->hasEffect('stealth')) {
+			$targetObj->addStatus(STEALTH);
+			$alternateResultMessage = "__TARGET__ is now stealthed.";
+			$targetResult = ' be shrouded in smoke.';
+		}
+
+		if ($item->hasEffect('vigor')) {
+			if ($targetObj->hasStatus(STR_UP1)) {
+				$result = "__TARGET__'s body cannot become more vigorous!";
+				$item_used = false;
 			} else {
-				// If it doesn't do damage or have an effect, don't use up the item.
-				if(!$item->isOtherUsable()){
-					$result = 'This item is not usable on __TARGET__, so it remains unused.';
-					$item_used = false;
-				} else {
-
-					// TODO: These result messages are screwed up (e.g. what gets sent to the events mail is wrongly phrased frequently now), and need to be reworked.
-
-					if ($item->hasEffect('stealth')) {
-						$targetObj->addStatus(STEALTH);
-						$alternateResultMessage = "__TARGET__ is now stealthed.";
-						$targetResult = ' to be shrouded in smoke';
-					}
-
-					if ($item->hasEffect('vigor')) {
-						if ($targetObj->hasStatus(STR_UP1)) {
-							$result = "__TARGET__'s body cannot become more vigorous!";
-							$item_used = false;
-						} else {
-							$targetObj->addStatus(STR_UP1);
-							$result = "__TARGET__'s muscles experience a strange tingling.";
-						}
-					}
-
-					if ($item->hasEffect('strength')) {
-						if ($targetObj->hasStatus(STR_UP2)) {
-							$result = "__TARGET__'s body cannot become any stronger!";
-							$item_used = false;
-						} else {
-							$targetObj->addStatus(STR_UP2);
-							$result = "__TARGET__ feels a surge of power!";
-						}
-					}
-
-					// Slow and speed effects are exclusive.
-					if ($item->hasEffect('slow')) {
-						$limited_effect = false;
-
-						if($targetObj->hasStatus(SLOW)){
-							$limited_effect = true; // Already slowed, so decreased effect.
-						} else {
-							if ($targetObj->hasStatus(FAST)) {
-								$targetObj->subtractStatus(FAST);
-							} else {
-								$targetObj->addStatus(SLOW);
-							}
-						}
-
-						$turns_change = $item->getTurnChange();
-
-						if($limited_effect){
-							// If the effect is already in play, it will have a decreased effect.
-							$turns_change = ceil($turns_change*0.3); // Decrease to partial effect.
-							$alternateResultMessage = "__TARGET__ is already moving slowly.";
-						}
-
-						if ($turns_change == 0) {
-							$alternateResultMessage .= " You fail to take any turns from __TARGET__.";
-						}
-
-						$targetResult         = " lose ".abs($turns_change)." turns";
-						$targetObj->subtractTurns($turns_change);
-					} else if ($item->hasEffect('speed')) {	// Note that speed and slow effects are exclusive.
-						$limited_effect = false;
-
-						if($targetObj->hasStatus(FAST)){
-							$limited_effect = true;
-						} else {
-							if ($targetObj->hasStatus(SLOW)) {
-								$targetObj->subtractStatus(SLOW);
-							} else {
-								$targetObj->addStatus(FAST);
-							}
-						}
-
-						$turns_change = $item->getTurnChange();
-
-						if($limited_effect){
-							// If the effect is already in play, it will have a decreased effect.
-							$turns_change = ceil($turns_change*0.5); // Decrease to partial effect.
-							$alternateResultMessage = "__TARGET__ is already moving quickly.";
-						}
-
-						// Actual turn gain is 1 less because 1 is used each time you use an item.
-						$targetResult         = "gain $turns_change turns.";
-						$targetObj->changeTurns($turns_change); // Still adding some turns.
-					}
-
-					if ($item->getTargetDamage() > 0) { // *** HP Altering ***
-						$alternateResultMessage .= " __TARGET__ takes ".$item->getTargetDamage()." damage.";
-
-						if ($self_use) {
-							$result .= "You take ".$item->getTargetDamage()." damage!";
-						} else {
-							$targetResult = " take ".$item->getTargetDamage()." damage!";
-						}
-
-						$targetObj->vo->health = $victim_alive = $targetObj->subtractHealth($item->getTargetDamage());
-						// This is the other location that $victim_alive is set, to determine whether the death proceedings should occur.
-					}
-
-					if ($item->hasEffect('death')) {
-						$targetObj->vo->health = setHealth($target_id, 0);
-						$victim_alive = false;
-						$targetResult = " be drained of your life-force and die!";
-						$gold_mod = 0.25;          //The Dim Mak takes away 25% of a targets' gold.
-					}
-				}// End of check that it's usable on someone else.
-			}// End of the item use (as opposed to giving) section.
-
-			if (!$error) { // Unless there's an error, determine the resultMessages and assign kills and loot.
-				// *** Message to display based on item type ***
-				if ($item->hasEffect('death')) {
-					$resultMessage = "The life force drains from __TARGET__ and they drop dead before your eyes!.";
-				}
-
-				if ($turns_change !== null) { // Even if $turns_change is set to zero, let them know that.
-					if ($turns_change <= 0) {
-						if($turns_change == 0){
-							$resultMessage .= "__TARGET__ did not lose any turns!";
-						} else {
-							$resultMessage .= "__TARGET__ has lost ".abs($turns_change)." turns!";
-						}
-
-						if (getTurns($target_id) <= 0) { //Message when a target has no more turns to ice scroll away.
-							$resultMessage .= "  __TARGET__ no longer has any turns.";
-						}
-					} else if ($turns_change > 0) {
-						$resultMessage .= "__TARGET__ has gained back $turns_change turns!";
-					}
-				}
-
-				if (empty($resultMessage) && !empty($result)) {
-					$resultMessage = $result;
-				}
-
-				if (!$victim_alive) { // Target was killed by the item.
-					if (!$self_use) {   // *** SUCCESSFUL KILL, not self-use of an item ***
-						$attacker_id = ($player->hasStatus(STEALTH) ? "A Stealthed Ninja" : $username);
-
-						if (!$gold_mod) {
-							$gold_mod = 0.15;
-						}
-
-						$loot = round($gold_mod * get_gold($target_id));
-						subtract_gold($target_id, $loot);
-						add_gold($char_id, $loot);
-						addKills($char_id, 1);
-						$kill = true;
-						$bountyMessage = runBountyExchange($username, $target);  //Rewards or increases bounty.
-					} else {
-						$loot = 0;
-						$suicide = true;
-					}
-
-					// Send mails if the target was killed.
-					send_kill_mails($username, $target, $attacker_id, $article, $item->getName(), $today, $loot);
-				} else { // They weren't killed.
-					$attacker_id = $username;
-				}
-
-				if (!$self_use) {
-					if (!$targetResult) {
-						error_log('Debug: Issue 226 - An attack was made using '.$item->getName().', but no targetResult message was set.');
-					}
-
-					// Notify targets when they get an item used on them.
-					$message_to_target = "$attacker_id has used $article {$item->getName()} on you at $today and caused you to $targetResult.";
-					send_event($user_id, $target_id, $message_to_target);
-				}
-			}
-
-			$targetName = $targetObj->vo->uname;
-			$targetHealth = $targetObj->vo->health;
-			$targetHealthPercent = $targetObj->health_percent();
-
-			$turns_to_take = 1;
-
-			if ($item_used) {
-				// *** remove Item ***
-				removeItem($user_id, $item->getName(), 1); // *** Decreases the item amount by 1.
-			}
-
-			$stealthLost = false;
-			// Unstealth
-			if (!$item->isCovert() && !$item->hasEffect('stealth') && !$give && $player->hasStatus(STEALTH)) { //non-covert acts
-				$player->subtractStatus(STEALTH);
-				$stealthLost = true;
-			}
-
-			if ($victim_alive && $using_item) {
-				$repeat = true;
+				$targetObj->addStatus(STR_UP1);
+				$result = "__TARGET__'s muscles experience a strange tingling.";
 			}
 		}
+
+		if ($item->hasEffect('strength')) {
+			if ($targetObj->hasStatus(STR_UP2)) {
+				$result = "__TARGET__'s body cannot become any stronger!";
+				$item_used = false;
+			} else {
+				$targetObj->addStatus(STR_UP2);
+				$result = "__TARGET__ feels a surge of power!";
+			}
+		}
+
+		// Slow and speed effects are exclusive.
+		if ($item->hasEffect('slow')) {
+			$turns_change = $item->getTurnChange();
+
+			if ($targetObj->hasStatus(SLOW)) {
+				// If the effect is already in play, it will have a decreased effect.
+				$turns_change = ceil($turns_change*0.3);
+				$alternateResultMessage = "__TARGET__ is already moving slowly.";
+			} else if ($targetObj->hasStatus(FAST)) {
+				$targetObj->subtractStatus(FAST);
+			} else {
+				$targetObj->addStatus(SLOW);
+			}
+
+			if ($turns_change == 0) {
+				$alternateResultMessage .= " You fail to take any turns from __TARGET__.";
+			}
+
+			$targetResult = " lose ".abs($turns_change)." turns.";
+			$targetObj->subtractTurns($turns_change);
+		} else if ($item->hasEffect('speed')) {	// Note that speed and slow effects are exclusive.
+			$turns_change = $item->getTurnChange();
+
+			if ($targetObj->hasStatus(FAST)) {
+				// If the effect is already in play, it will have a decreased effect.
+				$turns_change = ceil($turns_change*0.5);
+				$alternateResultMessage = "__TARGET__ is already moving quickly.";
+			} else if ($targetObj->hasStatus(SLOW)) {
+				$targetObj->subtractStatus(SLOW);
+			} else {
+				$targetObj->addStatus(FAST);
+			}
+
+			// Actual turn gain is 1 less because 1 is used each time you use an item.
+			$targetResult = " gain $turns_change turns.";
+			$targetObj->changeTurns($turns_change); // Still adding some turns.
+		}
+
+		if ($item->getTargetDamage() > 0) { // *** HP Altering ***
+			$alternateResultMessage .= " __TARGET__ takes ".$item->getTargetDamage()." damage.";
+
+			if ($self_use) {
+				$result .= "You take ".$item->getTargetDamage()." damage!";
+			} else {
+				$targetResult = " take ".$item->getTargetDamage()." damage!";
+			}
+
+			$targetObj->vo->health = $victim_alive = $targetObj->subtractHealth($item->getTargetDamage());
+			// This is the other location that $victim_alive is set, to determine whether the death proceedings should occur.
+		}
+
+		if ($item->hasEffect('death')) {
+			$targetObj->vo->health = setHealth($target_id, 0);
+
+			$resultMessage = "The life force drains from __TARGET__ and they drop dead before your eyes!";
+			$victim_alive  = false;
+			$targetResult  = " be drained of your life-force and die!";
+			$gold_mod      = 0.25;          //The Dim Mak takes away 25% of a targets' gold.
+		}
+
+		if ($turns_change !== null) { // Even if $turns_change is set to zero, let them know that.
+			if ($turns_change > 0) {
+				$resultMessage .= "__TARGET__ has gained back $turns_change turns!";
+			} else {
+				if ($turns_change === 0) {
+					$resultMessage .= "__TARGET__ did not lose any turns!";
+				} else {
+					$resultMessage .= "__TARGET__ has lost ".abs($turns_change)." turns!";
+				}
+
+				if (getTurns($target_id) <= 0) { //Message when a target has no more turns to ice scroll away.
+					$resultMessage .= "  __TARGET__ no longer has any turns.";
+				}
+			}
+		}
+
+		if (empty($resultMessage) && !empty($result)) {
+			$resultMessage = $result;
+		}
+
+		if (!$victim_alive) { // Target was killed by the item.
+			if (!$self_use) {   // *** SUCCESSFUL KILL, not self-use of an item ***
+				$attacker_id = ($player->hasStatus(STEALTH) ? "A Stealthed Ninja" : $username);
+
+				if (!$gold_mod) {
+					$gold_mod = 0.15;
+				}
+
+				$loot = round($gold_mod * get_gold($target_id));
+				subtract_gold($target_id, $loot);
+				add_gold($char_id, $loot);
+				addKills($char_id, 1);
+				$kill = true;
+				$bountyMessage = runBountyExchange($username, $target);  //Rewards or increases bounty.
+			} else {
+				$loot = 0;
+				$suicide = true;
+			}
+
+			// Send mails if the target was killed.
+			send_kill_mails($username, $target, $attacker_id, $article, $item->getName(), $today, $loot);
+		} else { // They weren't killed.
+			$attacker_id = $username;
+		}
+
+		if (!$self_use) {
+			if (!$targetResult) {
+				error_log('Debug: Issue 226 - An attack was made using '.$item->getName().', but no targetResult message was set.');
+			}
+
+			// Notify targets when they get an item used on them.
+			$message_to_target = "$attacker_id has used $article {$item->getName()} on you at $today and caused you to $targetResult";
+			send_event($user_id, $target_id, str_replace('  ', ' ', $message_to_target));
+		}
+
+		// Unstealth
+		if (!$item->isCovert() && !$item->hasEffect('stealth') && $player->hasStatus(STEALTH)) { //non-covert acts
+			$player->subtractStatus(STEALTH);
+			$stealthLost = true;
+		} else {
+			$stealthLost = false;
+		}
+	}
+
+	$targetName          = $targetObj->vo->uname;
+	$targetHealth        = $targetObj->vo->health;
+	$targetHealthPercent = $targetObj->health_percent();
+
+	$turns_to_take = 1;
+
+	if ($item_used) { // *** remove Item ***
+		removeItem($user_id, $item->getName(), 1); // *** Decreases the item amount by 1.
+	}
+
+	if ($victim_alive && $using_item) {
+		$repeat = true;
 	}
 }
 

--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -223,8 +223,10 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 				$alternateResultMessage = "__TARGET__ is already moving slowly.";
 			} else if ($targetObj->hasStatus(FAST)) {
 				$targetObj->subtractStatus(FAST);
+				$alternateResultMessage = "__TARGET__ is no longer moving quickly.";
 			} else {
 				$targetObj->addStatus(SLOW);
+				$alternateResultMessage = "__TARGET__ begins to move slowly...";
 			}
 
 			if ($turns_change == 0) {
@@ -242,8 +244,10 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 				$alternateResultMessage = "__TARGET__ is already moving quickly.";
 			} else if ($targetObj->hasStatus(SLOW)) {
 				$targetObj->subtractStatus(SLOW);
+				$alternateResultMessage = "__TARGET__ is no longer moving slowly.";
 			} else {
 				$targetObj->addStatus(FAST);
+				$alternateResultMessage = "__TARGET__ begins to move quickly!";
 			}
 
 			// Actual turn gain is 1 less because 1 is used each time you use an item.

--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -324,7 +324,12 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 			}
 
 			// Notify targets when they get an item used on them.
-			$message_to_target = "$attacker_id has used $article {$item->getName()} on you at $today and caused you to $targetResult";
+			$message_to_target = "$attacker_id has used $article {$item->getName()} on you at $today";
+			if($targetResult){ 
+				$message_to_target .= " and caused you to $targetResult"; 
+			} else {
+				$message_to_target .= '.';
+			}
 			send_event($user_id, $target_id, str_replace('  ', ' ', $message_to_target));
 		}
 

--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -147,7 +147,7 @@ $itemType = $item->getType();
 $article = get_indefinite_article($item_obj->getName());
 
 if ($give) {
-	$turn_cost  = 0;
+	$turn_cost  = 1;
 	$using_item = false;
 } else {
 	$turn_cost  = $item->getTurnCost();

--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -182,10 +182,10 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 		$alternateResultMessage = "__TARGET__ will receive your {$item->getName()}.";
 	} else if (!$item->isOtherUsable()) {
 		// If it doesn't do damage or have an effect, don't use up the item.
-		$result    = 'This item is not usable on __TARGET__, so it remains unused.';
+		$resultMessage = $result    = 'This item is not usable on __TARGET__, so it remains unused.';
 		$item_used = false;
+		$using_item = false;
 	} else {
-		// TODO: These result messages are screwed up (e.g. what gets sent to the events mail is wrongly phrased frequently now), and need to be reworked.
 
 		if ($item->hasEffect('stealth')) {
 			$targetObj->addStatus(STEALTH);
@@ -197,6 +197,7 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 			if ($targetObj->hasStatus(STR_UP1)) {
 				$result = "__TARGET__'s body cannot become more vigorous!";
 				$item_used = false;
+				$using_item = false;
 			} else {
 				$targetObj->addStatus(STR_UP1);
 				$result = "__TARGET__'s muscles experience a strange tingling.";
@@ -207,6 +208,7 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 			if ($targetObj->hasStatus(STR_UP2)) {
 				$result = "__TARGET__'s body cannot become any stronger!";
 				$item_used = false;
+				$using_item = false;
 			} else {
 				$targetObj->addStatus(STR_UP2);
 				$result = "__TARGET__ feels a surge of power!";
@@ -261,7 +263,6 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 			if ($self_use) {
 				$result .= "You take ".$item->getTargetDamage()." damage!";
 			} else {
-
 				if(strlen($targetResult) > 0){
 					$targetResult .= " You also"; // Join multiple targetResult messages.
 				}
@@ -291,7 +292,7 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 					$resultMessage .= "__TARGET__ has lost ".abs($turns_change)." turns!";
 				}
 
-				if (getTurns($target_id) <= 0) { //Message when a target has no more turns to ice scroll away.
+				if (getTurns($target_id) <= 0) { //Message when a target has no more turns to remove.
 					$resultMessage .= "  __TARGET__ no longer has any turns.";
 				}
 			}
@@ -366,7 +367,6 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 }
 
 // *** Take away at least one turn even on attacks that fail to prevent page reload spamming ***
-// TODO: Once attack attempt limiting works, this can be removed.
 if ($turns_to_take < 1) {
 	$turns_to_take = 1;
 }

--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -261,7 +261,11 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 			if ($self_use) {
 				$result .= "You take ".$item->getTargetDamage()." damage!";
 			} else {
-				$targetResult = " take ".$item->getTargetDamage()." damage!";
+
+				if(strlen($targetResult) > 0){
+					$targetResult .= " You also"; // Join multiple targetResult messages.
+				}
+				$targetResult .= " take ".$item->getTargetDamage()." damage!";
 			}
 
 			$targetObj->vo->health = $victim_alive = $targetObj->subtractHealth($item->getTargetDamage());


### PR DESCRIPTION
Resolve #264
Created a new concept called a "targetMessage" and use that when
generating messages to the target of an item use.