### PR TITLE
Make test suites runnable separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,10 @@
+.PHONY: test test-integration test-unit
+
 test:
 	@./vendor/bin/phpunit
+
+test-unit:
+	@./vendor/bin/phpunit --testsuite Unit
+
+test-integration:
+	@./vendor/bin/phpunit --testsuite Integration

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,8 +10,10 @@
 	stopOnIncomplete="false"
 	stopOnSkipped="false">
 	<testsuites>
-		<testsuite name="Ninja Wars Test Suite">
+		<testsuite name="Unit">
 			<directory suffix=".php">deploy/tests/unit</directory>
+		</testsuite>
+		<testsuite name="Integration">
 			<directory suffix=".php">deploy/tests/integration</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
New make targets added (test-unit and test-integration) to allow for
running suites separately (make test is unaffected). To make this easy
the suite names were renamed to simply Unit and Integration