### PR TITLE
Move code-coverage flag and dir to variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,12 @@ deploy/model/orm/*
 !deploy/model/orm/.gitkeep
 !deploy/sql/.gitkeep
 deploy/
-# Ignore codecoverage reports
-deploy/tests/cc
+
+#ignore developer specific GNU make configuration for this project
+CONFIG
+
+# Ignore codecoverage reports wherever they reside
+/cc/
 
 # Propel build
 build.properties

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 .PHONY: test test-integration test-unit
 
 CC_DIR=./cc
+CC_FLAG=--coverage-html $(CC_DIR)
+
+-include CONFIG
 
 ifdef NOCOVER
 CC_FLAG=
-else
-CC_FLAG=--coverage-html $(CC_DIR)
 endif
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 .PHONY: test test-integration test-unit
 
+CC_DIR=./cc
+
+ifdef NOCOVER
+CC_FLAG=
+else
+CC_FLAG=--coverage-html $(CC_DIR)
+endif
+
 test:
-	@./vendor/bin/phpunit --coverage-html ./deploy/tests/cc
+	@./vendor/bin/phpunit $(CC_FLAG)
 
 test-unit:
-	@./vendor/bin/phpunit --coverage-html ./deploy/tests/cc --testsuite Unit
+	@./vendor/bin/phpunit $(CC_FLAG) --testsuite Unit
 
 test-integration:
-	@./vendor/bin/phpunit --coverage-html ./deploy/tests/cc --testsuite Integration
+	@./vendor/bin/phpunit $(CC_FLAG) --testsuite Integration

--- a/configure
+++ b/configure
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "CC_DIR=./cc/" > CONFIG


### PR DESCRIPTION
To invoke tests without code coverage run "make test NOCOVER=true"