### PR TITLE
Playerify: Merge in get_gold refactors and some more.

### DIFF
--- a/deploy/lib/control/Player.class.php
+++ b/deploy/lib/control/Player.class.php
@@ -474,7 +474,8 @@ class Player implements Character {
 	 */
 	public function save(){
 		$factory = new PlayerDAO();
-		return $factory->save($this->vo);
+		$updated = $factory->save($this->vo);
+		return $this;
 	}
 
 }

--- a/deploy/lib/control/WorkController.php
+++ b/deploy/lib/control/WorkController.php
@@ -50,7 +50,7 @@ class WorkController {
             'is_logged_in'           => $is_logged_in,
             'gold_display'           => $gold_display,
             'worked'                 => $worked,
-            'earned_gold'            => $earned_gold,
+            'earned_gold'            => number_format($earned_gold),
             'not_enough_energy'      => $not_enough_energy,
         ];
 
@@ -82,7 +82,7 @@ class WorkController {
             'is_logged_in'           => $is_logged_in,
             'gold_display'           => $gold_display,
             'worked'                 => $worked,
-            'earned_gold'            => $earned_gold,
+            'earned_gold'            => number_format($earned_gold),
             'not_enough_energy'      => $not_enough_energy,
         ];
 

--- a/deploy/lib/data/DataAccessObject.class.php
+++ b/deploy/lib/data/DataAccessObject.class.php
@@ -25,12 +25,13 @@ abstract class DataAccessObject {
 	public function save(ValueObject $vo) {
 		// *** Check the ID of the value object to see whether it was pre-existing.
 		if ($vo->{$this->_id_field} === null) {
-			$this->_insert($vo);
+			$outcome = $this->_insert($vo);
 			$this->_last_saved_or_updated = 'saved';
 		} else {
-			$this->_update($vo);
+			$outcome = (bool) $this->_update($vo);
 			$this->_last_saved_or_updated = 'updated';
 		}
+		return $outcome;
 	}
 
 	public function get($id) {
@@ -108,6 +109,7 @@ abstract class DataAccessObject {
 
 		$statement->bindValue(':id', intval($vo->{$this->_id_field}));
 		$statement->execute();
+		return $statement->rowCount();
 	}
 
 	private function _insert($vo) {
@@ -141,5 +143,6 @@ abstract class DataAccessObject {
 		// The new id is set at the beginning of the function.
 		// set id on vo
 		$vo->{$this->_id_field} = $new_id;
+		return $new_id;
 	}
 }

--- a/deploy/lib/data/PlayerDAO.class.php
+++ b/deploy/lib/data/PlayerDAO.class.php
@@ -53,7 +53,7 @@ class PlayerDAO extends DataAccessObject {
 		unset($vo2->identity);
 		unset($vo2->class_name);
 		unset($vo2->theme);
-		parent::save($vo2);
+		return parent::save($vo2);
 	}
 
 	/**

--- a/deploy/templates/skills_mod.tpl
+++ b/deploy/templates/skills_mod.tpl
@@ -1,4 +1,7 @@
 
+{assign var="charName" value=$target->name()|escape}
+{assign var="charName" value="<strong class=\"char-name\">$charName</strong>"}
+
 <section>
 	<h1>Skill Effect</h1>
 
@@ -32,8 +35,7 @@
   </table>
 	{/if}
 
-	{assign var="charName" value=$target|escape}
-	{assign var="charName" value="<strong class=\"char-name\">$charName</strong>"}
+
 
 	{if $generic_skill_result_message}
   {$generic_skill_result_message|replace:'__TARGET__':$charName}

--- a/deploy/templates/stats.tpl
+++ b/deploy/templates/stats.tpl
@@ -17,7 +17,7 @@
 </style>
 
 
-<h1>Ninja Stats for {$username|escape}</h1>
+<h1>Ninja Stats for {$char->name()|escape}</h1>
 
 <div id='content' class='your-stats'>
 
@@ -65,10 +65,10 @@
       </li>
       <li>Turns: <span class='turns-count'>{$player.turns|escape}</span></li>
       <li>Kills: {$player.kills|escape}</li>
-      <li class='gold-count'>Gold: {$player.gold|escape}</li>
+      <li class='gold-count'>Gold: {$gold_display|escape}</li>
       <li>Created: <time class='timeago' datetime='{$player.created_date|escape}'>{$player.created_date|escape}</time></li>
       <li>Rank: {$rank_display|escape}</li>
-      <li>Bounty: <span class='gold-count'>{$player.bounty|escape} gold</span></li>
+      <li>Bounty: <span class='gold-count'>{$bounty_display|escape} gold</span></li>
         {if $player_clan}
       <li>
         Clan:

--- a/deploy/www/inventory_mod.php
+++ b/deploy/www/inventory_mod.php
@@ -312,10 +312,12 @@ if (!$attack_allowed) { //Checks for error conditions before starting.
 				if (!$gold_mod) {
 					$gold_mod = 0.15;
 				}
-
-				$loot = round($gold_mod * get_gold($target_id));
-				subtract_gold($target_id, $loot);
-				add_gold($user_id, $loot);
+				$initial_gold = $targetObj->gold();
+				$loot = floor($gold_mod * $initial_gold);
+				$targetObj->set_gold($initial_gold-$loot);
+				$player->set_gold($player->gold()+$loot);
+				$player->save();
+				$targetObj->save();
 				addKills($user_id, 1);
 				$kill = true;
 				$bountyMessage = runBountyExchange($player->name(), $target);  //Rewards or increases bounty.

--- a/deploy/www/skills_mod.php
+++ b/deploy/www/skills_mod.php
@@ -129,9 +129,7 @@ if (!$attack_error) { // Nothing to prevent the attack from happening.
 	} elseif ($command == 'Steal') {
 		$covert = true;
 
-		$gold_decrease = rand(1, 50);
-		$target_gold   = $target->vo->gold;
-		$gold_decrease = ($target_gold < $gold_decrease ? $target_gold : $gold_decrease);
+		$gold_decrease = min($target->gold(), rand(5, 50));
 
 		add_gold($char_id, $gold_decrease); // *** This one actually adds the value.
 		subtract_gold($target->id(), $gold_decrease); // *** Subtracts whatever positive value is put in.
@@ -358,10 +356,11 @@ if (!$attack_error) { // Nothing to prevent the attack from happening.
 		} else { // Attacker killed someone else.
 			$killed_target = true;
 			$gold_mod = 0.15;
-			$loot     = round($gold_mod * get_gold($target->id()));
-
-			subtract_gold($target->id(), $loot);
-			add_gold($char_id, $loot);
+			$loot     = floor($gold_mod * $target->gold());
+			$player->set_gold($player->gold()+$loot);
+			$target->set_gold($target->gold()-$loot);
+			$player->save();
+			$target->save();
 
 			addKills($char_id, 1);
 


### PR DESCRIPTION
Refactoring away a lot of get_gold to $char->gold()
Display some of the gold output results more readably (with commas every third place)
partial move from `round()` (rounding up from 0.5 onwards is almost never the intended behavior) to `floor()` 
Planning to do some refactoring of attack_mod, so I want to merge this in underneath to avoid conflicts later.  Playerify efforts will rise again later.