### PR TITLE
Times and dates using timestamps with time zone

### DIFF
--- a/deploy/db/migrations/20160223_date_fixes.sql
+++ b/deploy/db/migrations/20160223_date_fixes.sql
@@ -1,0 +1,27 @@
+alter table players alter column created_date type timestamp with time zone;
+alter table players alter column last_started_attack type timestamp with time zone;
+alter table chat alter column date type timestamp with time zone;
+alter table account_news alter column created_date type timestamp with time zone;
+alter table account_players alter column created_date type timestamp with time zone;
+alter table account_players alter column last_login type timestamp with time zone;
+alter table accounts alter column created_date type timestamp with time zone;
+alter table accounts alter column last_login type timestamp with time zone;
+alter table accounts alter column last_login_failure type timestamp with time zone;
+alter table clan alter column clan_created_date type timestamp with time zone;
+alter table events alter column date type timestamp with time zone;
+alter table login_attempts alter column attempt_date type timestamp with time zone;
+alter table messages alter column date type timestamp with time zone;
+alter table news alter column created type timestamp with time zone;
+alter table news alter column updated type timestamp with time zone;
+alter table password_reset_requests alter column created_at type timestamp with time zone;
+alter table ppl_online alter column activity type timestamp with time zone;
+
+alter table password_reset_requests add column updated_at timestamp with time zone default now();
+alter table flags add column created_at timestamp with time zone default now();
+alter table clan_player add column created_at timestamp with time zone default now();
+alter table levelling_log alter column killsdate set default now();
+
+
+alter table players alter column resurrection_time set default round(random() * (23)::double precision);
+alter table players_flagged rename column timestamp to date;
+

--- a/deploy/db/migrations/20160223_deprecated_table_and_column_fixes.sql
+++ b/deploy/db/migrations/20160223_deprecated_table_and_column_fixes.sql
@@ -1,0 +1,2 @@
+alter table inventory drop column item_type_string_backup;
+drop table duped_unames;

--- a/deploy/sql/custom_schema_migrations.sql
+++ b/deploy/sql/custom_schema_migrations.sql
@@ -6,3 +6,28 @@ CREATE VIEW rankings AS
     SELECT player_rank.rank_id, players.player_id, player_rank.score, players.uname, class.class_name, players.level, (CASE WHEN (players.health = 0) THEN 0 ELSE 1 END)::boolean AS alive, players.days FROM ((player_rank JOIN players ON ((players.player_id = player_rank._player_id))) JOIN class ON ((class.class_id = players._class_id))) WHERE (players.active = 1) ORDER BY player_rank.rank_id;
 
 ALTER VIEW rankings owner to developers;
+
+alter table players alter column resurrection_time set default round(random() * (23)::double precision);
+
+alter table players alter column created_date type timestamp with time zone;
+alter table players alter column last_started_attack type timestamp with time zone;
+alter table chat alter column date type timestamp with time zone;
+alter table account_news alter column created_date type timestamp with time zone;
+alter table account_players alter column created_date type timestamp with time zone;
+alter table account_players alter column last_login type timestamp with time zone;
+alter table accounts alter column created_date type timestamp with time zone;
+alter table accounts alter column last_login type timestamp with time zone;
+alter table accounts alter column last_login_failure type timestamp with time zone;
+alter table clan alter column clan_created_date type timestamp with time zone;
+alter table events alter column date type timestamp with time zone;
+alter table login_attempts alter column attempt_date type timestamp with time zone;
+alter table messages alter column date type timestamp with time zone;
+alter table news alter column created type timestamp with time zone;
+alter table news alter column updated type timestamp with time zone;
+alter table password_reset_requests alter column created_at type timestamp with time zone;
+alter table ppl_online alter column activity type timestamp with time zone;
+
+#Have to custom alter these ones as well, created by schema.xml
+alter table password_reset_requests alter column updated_at type timestamp with time zone;
+alter table flags alter column created_at type timestamp with time zone;
+alter table clan_player alter column created_at type timestamp with time zone;

--- a/deploy/sql/schema.sql
+++ b/deploy/sql/schema.sql
@@ -1,8 +1,3 @@
-SET statement_timeout = 0;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
-SET check_function_bodies = false;
-SET client_min_messages = warning;
 
 -----------------------------------------------------------------------
 -- accounts
@@ -20,9 +15,9 @@ CREATE TABLE "accounts"
     "active_email" TEXT NOT NULL,
     "type" INTEGER DEFAULT 0,
     "operational" BOOLEAN DEFAULT 't',
-    "created_date" TIMESTAMP DEFAULT now() NOT NULL,
-    "last_login" TIMESTAMP,
-    "last_login_failure" TIMESTAMP,
+    "created_date" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    "last_login" TIMESTAMP WITH TIME ZONE,
+    "last_login_failure" TIMESTAMP WITH TIME ZONE,
     "karma_total" INTEGER DEFAULT 0 NOT NULL,
     "last_ip" VARCHAR(100),
     "confirmed" INTEGER DEFAULT 0 NOT NULL,
@@ -61,9 +56,9 @@ CREATE TABLE "players"
     "member" INTEGER DEFAULT 0 NOT NULL,
     "days" INTEGER DEFAULT 0 NOT NULL,
     "bounty" INTEGER DEFAULT 0 NOT NULL,
-    "created_date" TIMESTAMP DEFAULT now(),
+    "created_date" TIMESTAMP WITH TIME ZONE DEFAULT now(),
     "resurrection_time" INTEGER DEFAULT (round((random() * (7)::double precision)) * (3)::double precision) NOT NULL,
-    "last_started_attack" TIMESTAMP DEFAULT now(),
+    "last_started_attack" TIMESTAMP WITH TIME ZONE DEFAULT now(),
     "energy" INTEGER DEFAULT 0 NOT NULL,
     "avatar_type" INTEGER DEFAULT 1 NOT NULL,
     "_class_id" INTEGER NOT NULL,
@@ -108,8 +103,8 @@ CREATE TABLE "account_players"
 (
     "_account_id" INTEGER NOT NULL,
     "_player_id" INTEGER NOT NULL,
-    "last_login" TIMESTAMP DEFAULT now() NOT NULL,
-    "created_date" TIMESTAMP DEFAULT now() NOT NULL,
+    "last_login" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    "created_date" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     PRIMARY KEY ("_account_id","_player_id"),
     CONSTRAINT "account_players__player_id_key" UNIQUE ("_player_id")
 );
@@ -125,7 +120,7 @@ CREATE TABLE "players_flagged"
     "players_flagged_id" serial NOT NULL,
     "player_id" INTEGER,
     "flag_id" INTEGER,
-    "timestamp" DATE DEFAULT now(),
+    "date" DATE DEFAULT now(),
     "originating_page" VARCHAR(50),
     "extra_notes" VARCHAR(100),
     PRIMARY KEY ("players_flagged_id")
@@ -140,7 +135,7 @@ DROP TABLE IF EXISTS "ppl_online" CASCADE;
 CREATE TABLE "ppl_online"
 (
     "session_id" VARCHAR(255) NOT NULL,
-    "activity" TIMESTAMP DEFAULT now() NOT NULL,
+    "activity" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     "member" BOOLEAN DEFAULT 'f' NOT NULL,
     "ip_address" VARCHAR(255) DEFAULT '' NOT NULL,
     "refurl" VARCHAR(255) DEFAULT '' NOT NULL,
@@ -206,8 +201,8 @@ CREATE TABLE "news"
     "news_id" serial NOT NULL,
     "title" VARCHAR(100) DEFAULT '' NOT NULL,
     "content" TEXT DEFAULT '' NOT NULL,
-    "created" TIMESTAMP DEFAULT now() NOT NULL,
-    "updated" TIMESTAMP DEFAULT now() NOT NULL,
+    "created" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    "updated" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     "tags" TEXT DEFAULT '',
     PRIMARY KEY ("news_id")
 );
@@ -225,7 +220,7 @@ CREATE TABLE "password_reset_requests"
     "request_id" serial NOT NULL,
     "_account_id" INTEGER NOT NULL,
     "nonce" VARCHAR(130) NOT NULL,
-    "created_at" TIMESTAMP DEFAULT now() NOT NULL,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     "used" BOOLEAN DEFAULT 'f' NOT NULL,
     PRIMARY KEY ("request_id")
 );
@@ -240,7 +235,7 @@ CREATE TABLE "account_news"
 (
     "_account_id" INTEGER NOT NULL,
     "_news_id" INTEGER NOT NULL,
-    "created_date" TIMESTAMP DEFAULT now() NOT NULL,
+    "created_date" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     PRIMARY KEY ("_account_id","_news_id")
 );
 
@@ -255,7 +250,7 @@ CREATE TABLE "chat"
     "chat_id" serial NOT NULL,
     "sender_id" INTEGER DEFAULT 0,
     "message" VARCHAR(255) NOT NULL,
-    "date" TIMESTAMP DEFAULT now() NOT NULL,
+    "date" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     PRIMARY KEY ("chat_id")
 );
 
@@ -271,7 +266,7 @@ CREATE TABLE "clan"
 (
     "clan_id" serial NOT NULL,
     "clan_name" VARCHAR(255) NOT NULL,
-    "clan_created_date" TIMESTAMP DEFAULT now() NOT NULL,
+    "clan_created_date" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     "clan_founder" TEXT,
     "clan_avatar_url" TEXT,
     "description" TEXT,
@@ -323,7 +318,7 @@ CREATE TABLE "duped_unames"
 (
     "uname" TEXT NOT NULL,
     "email" TEXT NOT NULL,
-    "created_date" TIMESTAMP NOT NULL,
+    "created_date" TIMESTAMP WITH TIME ZONE NOT NULL,
     "relative_age" INT2 NOT NULL,
     "player_id" INTEGER NOT NULL,
     "locked" BOOLEAN DEFAULT 'f' NOT NULL,
@@ -378,7 +373,7 @@ CREATE TABLE "events"
     "send_from" INTEGER DEFAULT 0,
     "message" TEXT NOT NULL,
     "unread" INTEGER DEFAULT 1 NOT NULL,
-    "date" TIMESTAMP DEFAULT now() NOT NULL,
+    "date" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     PRIMARY KEY ("event_id")
 );
 
@@ -487,7 +482,7 @@ CREATE TABLE "login_attempts"
     "ip" TEXT,
     "successful" INTEGER,
     "additional_info" TEXT,
-    "attempt_date" TIMESTAMP DEFAULT now(),
+    "attempt_date" TIMESTAMP WITH TIME ZONE DEFAULT now(),
     PRIMARY KEY ("attempt_id")
 );
 
@@ -501,7 +496,7 @@ CREATE TABLE "messages"
 (
     "message_id" serial NOT NULL,
     "message" TEXT NOT NULL,
-    "date" TIMESTAMP DEFAULT now() NOT NULL,
+    "date" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     "send_to" INTEGER,
     "send_from" INTEGER,
     "unread" INTEGER DEFAULT 1,
@@ -528,9 +523,9 @@ CREATE TABLE "quests"
     "rewards" TEXT DEFAULT '' NOT NULL,
     "obstacles" TEXT DEFAULT '' NOT NULL,
     "proof" TEXT DEFAULT '' NOT NULL,
-    "created_at" TIMESTAMP DEFAULT now() NOT NULL,
-    "updated_at" TIMESTAMP DEFAULT now() NOT NULL,
-    "expires_at" TIMESTAMP DEFAULT now() + interval ' 1 mon ' NOT NULL,
+    "created_at" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    "updated_at" TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    "expires_at" TIMESTAMP WITH TIME ZONE DEFAULT now() + interval ' 1 mon ' NOT NULL,
     "type" INTEGER,
     "difficulty" INTEGER,
     PRIMARY KEY ("quest_id")

--- a/schema.xml
+++ b/schema.xml
@@ -47,7 +47,7 @@
     <column name="days" phpName="Days" type="INTEGER" required="true" defaultValue="0"/>
     <column name="bounty" phpName="Bounty" type="INTEGER" required="true" defaultValue="0"/>
     <column name="created_date" phpName="CreatedDate" type="TIMESTAMP" required="false" defaultExpr="now()"/>
-    <column name="resurrection_time" phpName="ResurrectionTime" type="INTEGER" required="true" defaultValue="(round((random() * (7)::double precision)) * (3)::double precision)"/>
+    <column name="resurrection_time" phpName="ResurrectionTime" type="INTEGER" required="true" defaultValue="(round(random() * (23)::double precision))"/>
     <column name="last_started_attack" phpName="LastStartedAttack" type="TIMESTAMP" required="false" defaultExpr="now()"/>
     <column name="energy" phpName="Energy" type="INTEGER" required="true" defaultValue="0"/>
     <column name="avatar_type" phpName="AvatarType" type="INTEGER" required="true" defaultValue="1"/>

--- a/schema.xml
+++ b/schema.xml
@@ -98,7 +98,7 @@
     <column name="players_flagged_id" phpName="PlayersFlaggedId" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
     <column name="player_id" phpName="PlayerId" type="INTEGER" required="false"/>
     <column name="flag_id" phpName="FlagId" type="INTEGER" required="false"/>
-    <column name="timestamp" phpName="Timestamp" type="DATE" required="false" defaultExpr="now()"/>
+    <column name="date" phpName="Date" type="DATE" required="false" defaultExpr="now()"/>
     <column name="originating_page" phpName="OriginatingPage" type="VARCHAR" size="50" required="false"/>
     <column name="extra_notes" phpName="ExtraNotes" type="VARCHAR" size="100" required="false"/>
   </table>
@@ -218,20 +218,6 @@
       <index-column name="date"/>
     </index>
   </table>
-  <table name="duped_unames" phpName="DupedUnames" idMethod="native">
-    <column name="uname" phpName="Uname" type="LONGVARCHAR" required="true"/>
-    <column name="email" phpName="Email" type="LONGVARCHAR" required="true"/>
-    <column name="created_date" phpName="CreatedDate" type="TIMESTAMP" required="true"/>
-    <column name="relative_age" phpName="RelativeAge" type="SMALLINT" required="true"/>
-    <column name="player_id" phpName="PlayerId" type="INTEGER" primaryKey="true" required="true"/>
-    <column name="locked" phpName="Locked" type="BOOLEAN" required="true" defaultValue="false"/>
-    <index name="duped_unames_email_key">
-      <index-column name="email"/>
-    </index>
-    <index name="duped_unames_uname_key">
-      <index-column name="uname"/>
-    </index>
-  </table>
   <table name="effects" phpName="Effects" idMethod="native">
     <column name="effect_id" phpName="EffectId" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
     <column name="effect_identity" phpName="EffectIdentity" type="VARCHAR" size="500" required="true"/>
@@ -279,7 +265,6 @@
     <column name="amount" phpName="Amount" type="INTEGER" required="false" defaultValue="1"/>
     <column name="owner" phpName="Owner" type="INTEGER" required="true"/>
     <column name="item_type" phpName="ItemType" type="INTEGER" required="false"/>
-    <column name="item_type_string_backup" phpName="ItemTypeStringBackup" type="VARCHAR" required="false"/>
     <foreign-key foreignTable="players" name="inventory_owner_fkey" onDelete="CASCADE" onUpdate="CASCADE">
       <reference local="owner" foreign="player_id"/>
     </foreign-key>


### PR DESCRIPTION
Propel doesn't support timestamps with time zone, it turns out
So have to run a custom sql migration after it all to make them with time zone columns.

Fixes #508 