### PR TITLE
Rankings seq fix: They now count up from 1 again.

### DIFF
--- a/deploy/cron/deity_fiveminute.php
+++ b/deploy/cron/deity_fiveminute.php
@@ -11,8 +11,7 @@ use NinjaWars\core\data\DatabaseConnection;
 
 DatabaseConnection::getInstance();
 DatabaseConnection::$pdo->query('BEGIN TRANSACTION');
-DatabaseConnection::$pdo->query('TRUNCATE player_rank');
-DatabaseConnection::$pdo->query("SELECT setval('player_rank_rank_id_seq', 1, false)");
+DatabaseConnection::$pdo->query('TRUNCATE player_rank RESTART IDENTITY');
 
 $ranked_players = DatabaseConnection::$pdo->prepare('INSERT INTO player_rank (_player_id, score) SELECT player_id, ((level*:level_weight) + floor(gold/:gold_weight) + (CASE WHEN kills > (5*level) THEN 3000 + least(floor((kills - (5*level)) * .3), 2000) ELSE ((kills/(5*level))*3000) END) - (days*:inactivity_weight)) AS score FROM players WHERE active = 1 ORDER BY score DESC');
 $ranked_players->bindValue(':level_weight', RANK_WEIGHT_LEVEL);

--- a/deploy/db/migrations/2016-02-28-fix_player_rank_sequence.sql
+++ b/deploy/db/migrations/2016-02-28-fix_player_rank_sequence.sql
@@ -1,0 +1,2 @@
+alter table player_rank alter column rank_id set default nextval('player_rank_rank_id_seq'::regclass);
+drop sequence player_rank_rank_id_seq1;

--- a/schema.xml
+++ b/schema.xml
@@ -374,6 +374,9 @@
     <column name="rank_id" phpName="RankId" type="INTEGER" autoIncrement="true" required="true" primaryKey="true"/>
     <column name="_player_id" phpName="PlayerId" type="INTEGER" required="true"/>
     <column name="score" phpName="Score" type="INTEGER" required="false"/>
+    <foreign-key foreignTable="players" name="player_rank__player_id_fkey" onUpdate="CASCADE">
+      <reference local="_player_id" foreign="player_id"/>
+    </foreign-key>
   </table>
   <table name="time" phpName="Time" idMethod="native">
     <column name="time_id" phpName="TimeId" type="INTEGER" autoIncrement="true" required="true" primaryKey="true"/>


### PR DESCRIPTION
Manually migrated to live, you may want to run the sql migration on your end to prevent the same bug from popping up eventually on your local.