### PR TITLE
Stats unhardcoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,16 @@ env:
   - INSTALL=integration_install
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.6
+  - 7.0
 
 matrix:
   allow_failures:
-    - php: 5.4
-    - php: 5.5
+    - php: 7.0
   fast_finish: true
 
 before_install:
+
     - chmod ug+rx scripts/build/*.sh
     - chmod ug+rx scripts/travis/*
     #- git submodule init
@@ -23,6 +22,10 @@ before_install:
 
 install:
     - ./scripts/travis/$INSTALL
+    - echo -e "CC_DIR=./cc/\nDBNAME=nw\nCOMPOSER=composer\nDBUSER=ninjamaster\nDBCREATINGUSER=ninjamaster" > CONFIG
+    - make ci
+    - readlink -f deploy/resources.php
+    - cat deploy/resources.php
 
 after_install:
     - php -v
@@ -35,10 +38,10 @@ after_install:
     - curl http://nw.local
 
 
-script: ./scripts/travis/test
+script: make ci-test
 
 #Just to limit noise in the test area, this is separated
-after_script: cat selenium_log.txt
+after_script:
 
 after_failure: ls && composer --version && vendor/bin/phpunit --version && php --version && sudo apache2ctl --version && sudo apache2ctl -S && sudo tail -10 /var/log/apache2/error.log
 after_success: sudo apache2ctl -S && sudo tail -100 /var/log/apache2/error.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - INSTALL=integration_install
 
 php:
+  - 5.5
   - 5.6
   - 7.0
 

--- a/deploy/cron/deity_fiveminute.php
+++ b/deploy/cron/deity_fiveminute.php
@@ -1,11 +1,13 @@
 <?php
 require_once(substr(__FILE__, 0, (strpos(__FILE__, 'cron/'))).'resources.php');
+require_once(dirname(__DIR__.'..').'/core/base.inc.php');
 require_once(LIB_ROOT.'data/DatabaseConnection.php');
 require_once(LIB_ROOT.'environment/lib_assert.php');
 require_once(LIB_ROOT.'environment/status_defines.php'); // Status constant definitions.
 require_once(LIB_ROOT.'environment/lib_error_reporting.php');
 require_once(LIB_ROOT.'data/lib_db.php');
 require_once(LIB_ROOT."control/lib_deity.php"); // Deity-specific functions
+
 
 use NinjaWars\core\data\DatabaseConnection;
 

--- a/deploy/cron/deity_halfhour.php
+++ b/deploy/cron/deity_halfhour.php
@@ -1,5 +1,6 @@
 <?php
 require_once(substr(__FILE__, 0, (strpos(__FILE__, 'cron/'))).'resources.php');
+require_once(dirname(__DIR__.'..').'/core/base.inc.php');
 require_once(LIB_ROOT.'data/DatabaseConnection.php');
 require_once(LIB_ROOT.'environment/lib_assert.php');
 require_once(LIB_ROOT.'environment/status_defines.php'); // Status constant definitions.

--- a/deploy/cron/deity_hourly.php
+++ b/deploy/cron/deity_hourly.php
@@ -1,5 +1,6 @@
 <?php
 require_once(substr(__FILE__, 0, (strpos(__FILE__, 'cron/'))).'resources.php');
+require_once(dirname(__DIR__.'..').'/core/base.inc.php');
 require_once(LIB_ROOT.'data/DatabaseConnection.php');
 require_once(LIB_ROOT.'environment/lib_assert.php');
 require_once(LIB_ROOT.'environment/status_defines.php'); // Status constant definitions.

--- a/deploy/cron/deity_nightly.php
+++ b/deploy/cron/deity_nightly.php
@@ -6,6 +6,7 @@
  * @subpackage deity_lib
  */
 require_once(substr(__FILE__, 0, (strpos(__FILE__, 'cron/'))).'resources.php');
+require_once(dirname(__DIR__.'..').'/core/base.inc.php');
 require_once(LIB_ROOT.'data/DatabaseConnection.php');
 require_once(LIB_ROOT.'environment/lib_assert.php');
 require_once(LIB_ROOT.'environment/status_defines.php'); // Status constant definitions.

--- a/deploy/derived_constants.php
+++ b/deploy/derived_constants.php
@@ -34,6 +34,7 @@ define('MAX_PLAYER_LEVEL', 350);
 // Defines for avatar options.
 define('GRAVATAR', 1);
 
+define('NEW_PLAYER_INITIAL_STATS', 5);
 define('NEW_PLAYER_INITIAL_HEALTH', 150);
 define('LEVEL_UP_STAT_RAISE', 5);
 define('LEVEL_UP_HP_RAISE', 25);

--- a/deploy/derived_constants.php
+++ b/deploy/derived_constants.php
@@ -34,6 +34,9 @@ define('MAX_PLAYER_LEVEL', 350);
 // Defines for avatar options.
 define('GRAVATAR', 1);
 
+define('LEVEL_UP_STAT_RAISE', 5);
+define('LEVEL_UP_HP_RAISE', 25);
+
 // Constants for deity scripts
 define('MIN_PLAYERS_FOR_UNCONFIRM', 1000);
 define('MIN_DAYS_FOR_UNCONFIRM',    60);

--- a/deploy/derived_constants.php
+++ b/deploy/derived_constants.php
@@ -34,6 +34,7 @@ define('MAX_PLAYER_LEVEL', 350);
 // Defines for avatar options.
 define('GRAVATAR', 1);
 
+define('NEW_PLAYER_INITIAL_HEALTH', 150);
 define('LEVEL_UP_STAT_RAISE', 5);
 define('LEVEL_UP_HP_RAISE', 25);
 

--- a/deploy/lib/control/Player.class.php
+++ b/deploy/lib/control/Player.class.php
@@ -687,21 +687,21 @@ class Player implements Character {
      * Calculate a base str by level
      */
     public static function baseStrengthByLevel($level) {
-        return LEVEL_UP_STAT_RAISE * $level;
+        return NEW_PLAYER_INITIAL_STATS + (LEVEL_UP_STAT_RAISE * ($level-1));
     }
 
     /**
      * Calculate a base speed by level
      */
     public static function baseSpeedByLevel($level) {
-        return LEVEL_UP_STAT_RAISE * $level;
+        return NEW_PLAYER_INITIAL_STATS + (LEVEL_UP_STAT_RAISE * ($level-1));
     }
 
     /**
      * Calculate a base stamina by level
      */
     public static function baseStaminaByLevel($level) {
-        return LEVEL_UP_STAT_RAISE * $level;
+        return NEW_PLAYER_INITIAL_STATS + (LEVEL_UP_STAT_RAISE * ($level-1));
     }
 
     /**

--- a/deploy/lib/control/Player.class.php
+++ b/deploy/lib/control/Player.class.php
@@ -680,29 +680,28 @@ class Player implements Character {
      * Calculate a max health by a level
      */
     public static function maxHealthByLevel($level) {
-        $health_per_level = 25;
-        return 150 + round($health_per_level*($level-1));
+        return NEW_PLAYER_INITIAL_HEALTH + round(LEVEL_UP_HP_RAISE*($level-1));
     }
 
     /**
      * Calculate a base str by level
      */
     public static function baseStrengthByLevel($level) {
-        return 5 * $level;
+        return LEVEL_UP_STAT_RAISE * $level;
     }
 
     /**
      * Calculate a base speed by level
      */
     public static function baseSpeedByLevel($level) {
-        return 5 * $level;
+        return LEVEL_UP_STAT_RAISE * $level;
     }
 
     /**
      * Calculate a base stamina by level
      */
     public static function baseStaminaByLevel($level) {
-        return 5 * $level;
+        return LEVEL_UP_STAT_RAISE * $level;
     }
 
     /**

--- a/deploy/lib/control/Player.class.php
+++ b/deploy/lib/control/Player.class.php
@@ -685,6 +685,27 @@ class Player implements Character {
     }
 
     /**
+     * Calculate a base str by level
+     */
+    public static function baseStrengthByLevel($level) {
+        return 5 * $level;
+    }
+
+    /**
+     * Calculate a base speed by level
+     */
+    public static function baseSpeedByLevel($level) {
+        return 5 * $level;
+    }
+
+    /**
+     * Calculate a base stamina by level
+     */
+    public static function baseStaminaByLevel($level) {
+        return 5 * $level;
+    }
+
+    /**
      * The number of kills needed to level up to the next level.
      *
      * 5 more kills in cost for every level you go up.

--- a/deploy/lib/control/lib_accounts.php
+++ b/deploy/lib/control/lib_accounts.php
@@ -93,12 +93,17 @@ function create_ninja($send_name, $params=array()) {
 	$preconfirm  = (int) $params['preconfirm'];
 	$confirm     = (int) $params['confirm'];
 
+	$initial_hp = Player::maxHealthByLevel(1);
+	$initial_strength = Player::baseStrengthByLevel(1);
+	$initial_speed = Player::baseSpeedByLevel(1);
+	$initial_stamina = Player::baseStaminaByLevel(1);
+
 	// Create the initial player row.
 	$playerCreationQuery= "INSERT INTO players
 		 (uname, health, strength, speed, stamina, gold, messages, kills, turns, verification_number, active,
 		  _class_id, level,  status, member, days, bounty, created_date)
 		 VALUES
-		 (:username, '150', '5', '5', '5', '100', '', '0', '180', :verification_number, :active,
+		 (:username, :initial_hp, :initial_strength, :initial_speed, :initial_stamina, '100', '', '0', '180', :verification_number, :active,
 		 (SELECT class_id FROM class WHERE identity = :class_identity), '1', '1', '0', '0', '0', now())";
 	//  ***  Inserts the choices and defaults into the player table. Status defaults to stealthed. ***
 	$statement = DatabaseConnection::$pdo->prepare($playerCreationQuery);
@@ -106,6 +111,10 @@ function create_ninja($send_name, $params=array()) {
 	$statement->bindValue(':verification_number', $confirm);
 	$statement->bindValue(':active', $preconfirm);
 	$statement->bindValue(':class_identity', $class_identity);
+	$statement->bindValue(':initial_hp', $initial_hp);
+	$statement->bindValue(':initial_strength', $initial_strength);
+	$statement->bindValue(':initial_speed', $initial_speed);
+	$statement->bindValue(':initial_stamina', $initial_stamina);
 	$statement->execute();
 	return get_char_id($send_name);
 }

--- a/deploy/lib/control/lib_deity.php
+++ b/deploy/lib/control/lib_deity.php
@@ -7,6 +7,7 @@
  */
 
 use NinjaWars\core\data\DatabaseConnection;
+use \Player as Player;
 
 // Determine the score for ranking.
 function get_score_formula(){
@@ -75,12 +76,14 @@ function unconfirm_older_players_over_minimums($keep_players=2300, $unconfirm_da
 }
 
 // Take all characters, and heal them one step closer to their maximum base.
-function heal_characters($basic=8, $with_level=true, $maximum_heal='200'){
+function heal_characters($basic=8, $with_level=true){
+	$maximum_heal = Player::maxHealthByLevel(3);
 	/*
 	Goal:  Faster regen for higher level.
 	See the balance sheet: 
 	https://docs.google.com/spreadsheet/ccc?pli=1&key=0AkoUgtBBP00HdGs0Tmk4bC10TXN0SUJYXzdYMVpFZFE#gid=0
 	*/
+	$max_hp = Player::maxHealthByLevel(MAX_PLAYER_LEVEL);
 
 
 	$level_add = '+ cast(floor(level/10) AS int)';

--- a/deploy/templates/dojo.scroll.tpl
+++ b/deploy/templates/dojo.scroll.tpl
@@ -28,10 +28,10 @@
         </thead>
 {assign var="level_chart"   value=1}
 {assign var="kills_chart"   value=0}
-{assign var="str_chart"     value=5}
-{assign var="speed_chart"   value=5}
-{assign var="stamina_chart" value=5}
-{assign var="hp_chart"      value=150}
+{assign var="str_chart"     value=Player::baseStrengthByLevel(1)}
+{assign var="speed_chart"   value=Player::baseSpeedByLevel(1)}
+{assign var="stamina_chart" value=Player::baseStaminaByLevel(1)}
+{assign var="hp_chart"      value=Player::maxHealthByLevel(1)}
         <tbody>
 {section name="chart" start=1 loop=$max_level+1 step=1}
             <tr>
@@ -44,11 +44,11 @@
             </tr>
     {assign var="level_chart" value=1+$level_chart}
     {assign var="kills_chart" value=5+$kills_chart}
-    {assign var="str_chart" value=5+$str_chart}
-    {assign var="stamina_chart" value=5+$stamina_chart}
-    {assign var="speed_chart" value=5+$speed_chart}
-    {if $hp_chart lte $max_hp}
-        {assign var="hp_chart" value=25+$hp_chart}
+    {assign var="str_chart" value=LEVEL_UP_STAT_RAISE+$str_chart}
+    {assign var="stamina_chart" value=LEVEL_UP_STAT_RAISE+$stamina_chart}
+    {assign var="speed_chart" value=LEVEL_UP_STAT_RAISE+$speed_chart}
+    {if $hp_chart lt $max_hp}
+        {assign var="hp_chart" value=LEVEL_UP_HP_RAISE+$hp_chart}
     {/if}
 {/section}
         </tbody>

--- a/deploy/templates/stats.tpl
+++ b/deploy/templates/stats.tpl
@@ -54,7 +54,7 @@
           {$char->level|level_label} [{$char->level|escape}]
         </span>
       </li>
-      <li><span class='physical'>Strength: {$char->strength|escape}</span><span class='physical'>Speed: {$char->speed|escape}</span><span class='physical'>Stamina: {$char->stamina|escape}</span></li>
+      <li><span class='physical'>Strength: {$char->strength()|escape}</span><span class='physical'>Speed: {$char->speed()|escape}</span><span class='physical'>Stamina: {$char->stamina()|escape}</span></li>
       <li>Ki: {$char->ki|number_format:0|escape}</li>
       <li>Karma: {$char->karma|number_format:0|escape}</li>
       <li>

--- a/deploy/tests/integration/controller/ShrineControllerTest.php
+++ b/deploy/tests/integration/controller/ShrineControllerTest.php
@@ -108,7 +108,7 @@ class ShrineControllerTest extends PHPUnit_Framework_TestCase {
         $result = $cont->resurrect();
         $final_char = Player::find($this->char->id());
         $this->assertTrue(in_array('result-resurrect', $result['parts']['pageParts']));
-        $this->assertGreaterThan(50, $final_char->health());
+        $this->assertGreaterThan(floor(Player::maxHealthByLevel($this->char->level())/2), $final_char->health());
     }
 
     public function testAntidoteUnpoisoningOfPoisonedCharacter(){
@@ -131,7 +131,7 @@ class ShrineControllerTest extends PHPUnit_Framework_TestCase {
         $result = $cont->resurrect();
         $final_char = Player::find($this->char->id());
         $this->assertTrue(in_array('result-resurrect', $result['parts']['pageParts']));
-        $this->assertGreaterThan(50, $final_char->health());
+        $this->assertGreaterThan(floor(Player::maxHealthByLevel($this->char->level())/2), $final_char->health());
     }
 
     public function testKillCostResurrectWithChi() {


### PR DESCRIPTION
Recalc stats via defines (in repo initially), allows for a lot of flexibility of progression, positive, none, negative, etc.  Deity files respond to defines, though note that for now you have to "downgrade" player health manually in the database, as if they're at 3000 health currently the system won't drop them down (but it will heal them up appropriately).