### PR TITLE
Communism: Redux, dynamic str/sta/spe generation.

### DIFF
--- a/deploy/derived_constants.php
+++ b/deploy/derived_constants.php
@@ -34,11 +34,6 @@ define('MAX_PLAYER_LEVEL', 350);
 // Defines for avatar options.
 define('GRAVATAR', 1);
 
-define('NEW_PLAYER_INITIAL_STATS', 5);
-define('NEW_PLAYER_INITIAL_HEALTH', 150);
-define('LEVEL_UP_STAT_RAISE', 5);
-define('LEVEL_UP_HP_RAISE', 25);
-
 // Constants for deity scripts
 define('MIN_PLAYERS_FOR_UNCONFIRM', 1000);
 define('MIN_DAYS_FOR_UNCONFIRM',    60);

--- a/deploy/lib/control/SkillController.php
+++ b/deploy/lib/control/SkillController.php
@@ -32,7 +32,7 @@ class SkillController {
 	}
 
 	public function maxHarmonize(Player $pc){
-		return $pc->maxHealth();
+		return $pc->getMaxHealth();
 	}
 
 	/**

--- a/deploy/lib/control/SkillController.php
+++ b/deploy/lib/control/SkillController.php
@@ -13,8 +13,27 @@ class SkillController {
 	const ALIVE = true;
 	const PRIV  = true;
 
-	const HEAL_PER_LEVEL = 10;
-	const MAX_HARMONIZE = 100;
+	const MIN_POISON_TOUCH = 1;
+
+	public function maxPoisonTouch(){
+		return (int)floor(2/3*Player::maxHealthByLevel(1));
+	}
+
+
+	public function fireBoltBaseDamage(Player $pc){
+		return (int) (floor(Player::maxHealthByLevel($pc->level) / 3));
+	}
+
+	/**
+	 * Technically max -additional damage off the base
+	 */
+	public function fireBoltMaxDamage(Player $pc){
+		return (int) $pc->getStrength();
+	}
+
+	public function maxHarmonize(Player $pc){
+		return $pc->maxHealth();
+	}
 
 	/**
 	 * Initialize with any external state if necessary
@@ -142,7 +161,7 @@ class SkillController {
 
 		$path = RequestWrapper::getPathInfo();
 		$slugs = $this->parseSlugs($path);
-		// (fullpath0) /skill1/go2/firebolt3/tchalvak4/(beagle5/)
+		// (fullpath0) /skill1/go2/Fire%20Bolt3/tchalvak4/(beagle5/)
 		$act = isset($slugs[3])? $slugs[3] : null;
 		$target = isset($slugs[4])? $slugs[4] : null;
 		$target2 = isset($slugs[5])? $slugs[5] : null;
@@ -172,12 +191,11 @@ class SkillController {
 		//$stealth = in('stealth'); Unused?  What was this.
 
 		$skillListObj    = new Skill();
-		$poisonMaximum   = 100; // *** Before level-based addition.
-		$poisonMinimum   = 1;
+		// *** Before level-based addition.
 		$poisonTurnCost  = $skillListObj->getTurnCost('poison touch'); // wut
 		$turn_cost       = $skillListObj->getTurnCost(strtolower($act));
 		$ignores_stealth = $skillListObj->getIgnoreStealth($act);
-		$self_usable        = $skillListObj->getSelfUse($act);
+		$self_usable     = $skillListObj->getSelfUse($act);
 		$use_on_target   = $skillListObj->getUsableOnTarget($act);
 		$ki_cost 		 = 0; // Ki taken during use.
 		$reuse 			 = true;  // Able to reuse the skill.
@@ -322,7 +340,7 @@ class SkillController {
 				$target->addStatus(POISON);
 				$target->addStatus(WEAKENED); // Weakness kills strength.
 
-				$target_damage = rand($poisonMinimum, $poisonMaximum);
+				$target_damage = rand(self::MIN_POISON_TOUCH, $this->maxPoisonTouch());
 
 				$victim_alive = $target->subtractHealth($target_damage);
 				$generic_state_change = "__TARGET__ has been poisoned!";
@@ -331,7 +349,9 @@ class SkillController {
 				$msg = "You have been poisoned by $attacker_id";
 				send_event($attacker_char_id, $target->id(), $msg);
 			} elseif ($act == 'Fire Bolt') {
-				$target_damage = (5 * (ceil($player->level / 3)) + rand(1, $player->getStrength()));
+				
+				$target_damage = $this->fireBoltBaseDamage($player) + rand(1, $this->fireBoltMaxDamage($player));
+
 
 				$generic_skill_result_message = "__TARGET__ has taken $target_damage damage!";
 
@@ -358,7 +378,7 @@ class SkillController {
 				} else {
 					if(!$harmonize){
 						$original_health = $target->health;
-						$heal_points = $player->level*self::HEAL_PER_LEVEL;
+						$heal_points = $player->stamina+1;
 						$new_health = $target->heal($heal_points); // Won't heal more than possible
 						$healed_by = $new_health - $original_health;
 					} else {
@@ -556,7 +576,7 @@ class SkillController {
 	 */
 	private function harmonizeChakra(Player $char){
 		// Heal at most 100 or ki available or hurt by AND at least 0
-		$heal_for = (int) max(0, min(self::MAX_HARMONIZE, $char->is_hurt_by(), $char->ki));
+		$heal_for = (int) max(0, min($this->maxHarmonize($char), $char->is_hurt_by(), $char->ki));
 		if($heal_for > 0){
 			// If there's anything to heal, try.
 

--- a/deploy/lib/data/Player.php
+++ b/deploy/lib/data/Player.php
@@ -242,7 +242,7 @@ class Player implements Character {
      * @return int
      */
 	public function strength() {
-		$str = $this->vo->strength;
+        $str = NEW_PLAYER_INITIAL_STATS + $this->level * LEVEL_UP_STAT_RAISE;
 		if ($this->hasStatus(WEAKENED)) {
 			return (int) max(1, $str-(ceil($str*.25))); // 75%
 		} elseif ($this->hasStatus(STR_UP2)) {
@@ -262,7 +262,7 @@ class Player implements Character {
 	}
 
 	public function speed() {
-		$speed = $this->vo->speed;
+        $speed = NEW_PLAYER_INITIAL_STATS + $this->level * LEVEL_UP_STAT_RAISE;
 		if ($this->hasStatus(SLOW)) {
 			return (int) ($speed-(ceil($speed*.25)));
 		} else {
@@ -278,7 +278,7 @@ class Player implements Character {
 	}
 
 	public function stamina() {
-		$stam = $this->vo->stamina;
+		$stam = NEW_PLAYER_INITIAL_STATS + $this->level * LEVEL_UP_STAT_RAISE;
 		if ($this->hasStatus(POISON)) {
 			return (int) ($stam-(ceil($stam*.25)));
 		} else {

--- a/deploy/lib/data/Player.php
+++ b/deploy/lib/data/Player.php
@@ -409,14 +409,14 @@ class Player implements Character {
      * @return integer
      */
     public function getMaxHealth() {
-        return self::maxHealthByLevel($this->level);
+        return $this->stamina()*2;
     }
 
     /**
      * @return integer
      */
     public function max_health() {
-        return self::maxHealthByLevel($this->level);
+        return $this->stamina()*2;
     }
 
     /**

--- a/deploy/resources.build.php
+++ b/deploy/resources.build.php
@@ -46,6 +46,11 @@ class Constants {
     public static $trusted_proxies = ['104.130.111.36', '10.189.245.10'];
 }
 
+define('NEW_PLAYER_INITIAL_STATS', 10);
+define('NEW_PLAYER_INITIAL_HEALTH', 20);
+define('LEVEL_UP_STAT_RAISE', 0);
+define('LEVEL_UP_HP_RAISE', 0);
+
 // Seperate, tracked file for derived constants, that changes as they change.
 require(SERVER_ROOT."derived_constants.php");
 

--- a/deploy/resources.template.php
+++ b/deploy/resources.template.php
@@ -46,6 +46,11 @@ class Constants {
     public static $trusted_proxies = ['104.130.111.36', '10.189.245.10'];
 }
 
+define('NEW_PLAYER_INITIAL_STATS', 10);
+define('NEW_PLAYER_INITIAL_HEALTH', 20);
+define('LEVEL_UP_STAT_RAISE', 0);
+define('LEVEL_UP_HP_RAISE', 0);
+
 // Seperate, tracked file for derived constants, that changes as they change.
 require(SERVER_ROOT."derived_constants.php");
 

--- a/deploy/tests/integration/controller/SkillControllerTest.php
+++ b/deploy/tests/integration/controller/SkillControllerTest.php
@@ -215,4 +215,27 @@ class SkillControllerTest extends \PHPUnit_Framework_TestCase {
         $final_char = Player::find($this->char->id());
         $this->assertGreaterThan($initial_health, $final_char->health());
     }
+
+
+    public function testUseHarmonizeOnSelf(){
+        $this->char->set_turns(300);
+        $this->char->ki = 1000;
+        $this->char->vo->level = 20;
+        $this->char->harm(floor($this->char->getMaxHealth()/2));
+        $initial_health = $this->char->health();
+        $this->assertGreaterThan($initial_health, $this->char->getMaxHealth());
+        $this->char->save();
+
+        $request = Request::create('/skill/self_use/Harmonize/');
+        RequestWrapper::inject($request);
+        $controller = new SkillController();
+        $controller_outcome = $controller->selfUse();
+
+        $this->assertNotInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $controller_outcome, 
+                'A redirect was the outcome for the url: '
+                .($controller_outcome instanceof RedirectResponse? $controller_outcome->getTargetUrl() : ''));
+        $this->assertEquals('Harmonize', $controller_outcome['parts']['act']);
+        $final_char = Player::find($this->char->id());
+        $this->assertGreaterThan($initial_health, $final_char->health());
+    }
 }

--- a/deploy/tests/integration/controller/SkillControllerTest.php
+++ b/deploy/tests/integration/controller/SkillControllerTest.php
@@ -191,12 +191,14 @@ class SkillControllerTest extends \PHPUnit_Framework_TestCase {
 
     // TODO: test that self_use of things like Steal error or whatever the right behavior should be?
     // TODO: test that use of skills that aren't part of the users skillset error
+    // TODO: test that use of unstealth on another fails
+    // TODO: test that use of stealth on another fails.
 
     public function testUseHealOnSelfAsAHealingCharacter(){
         $this->char->setClass('dragon');
         $this->char->set_turns(300);
         $this->char->vo->level = 20;
-        $this->char->set_health(floor($this->char->getMaxHealth()/2));
+        $this->char->harm(floor($this->char->getMaxHealth()/2));
         $initial_health = $this->char->health();
         $this->assertGreaterThan($initial_health, $this->char->getMaxHealth());
         $this->char->save();


### PR DESCRIPTION
Note that this will require moving new define constants to the resources.php file.

Also fixed up the appropriate tests that were broken by this.

Templates have settings for 10 str/spe/sta and 20 health, but whatever
floats your boat, and it's not hard to replicate the current settings for live with the defines.

(150 hp + 25 per level, 5 str/spe/sta + 5 per level)