### PR TITLE
Guarantee at least 1 gold reward from NPCs with gold

### DIFF
--- a/deploy/lib/control/NpcController.php
+++ b/deploy/lib/control/NpcController.php
@@ -124,7 +124,9 @@ class NpcController { //extends controller
         if($reward_item){
             $divisor = self::ITEM_DECREASES_GOLD_FACTOR;
         }
-        return rand($npco->min_gold(), floor($npco->gold()/$divisor));
+
+        // Always earn at least 1 gold from NPCs that yield gold
+        return max(1, rand($npco->min_gold(), floor($npco->gold()/$divisor)));
     }
 
     /**


### PR DESCRIPTION
* Attempts to resolve intermittent test failure due to the PRNG resulting in 0 gold from an NPC encounter when we don't expect it.