### PR TITLE
Improve router

### DIFF
--- a/deploy/lib/Router.php
+++ b/deploy/lib/Router.php
@@ -70,11 +70,7 @@ class Router {
                     $response  = self::execute($mainRoute, $command);
                 }
 
-                if ($response instanceof RedirectResponse) {
-                    $response->send();
-                } else {
-                    self::render($response);
-                }
+                return $response;
             }
         }
     }

--- a/deploy/lib/control/AbstractController.php
+++ b/deploy/lib/control/AbstractController.php
@@ -1,0 +1,47 @@
+<?php
+namespace NinjaWars\core\control;
+
+use NinjaWars\core\data\Player;
+use NinjaWars\core\extensions\SessionFactory;
+
+abstract class AbstractController {
+    /**
+     * Check if a player can access any of this controllers methods
+     *
+     * This method is a holdover from old times when controllers were
+     * actually directly servable procedural scripts (ah the old days!)
+     * If a page required you to be alive or logged in, we checked if
+     * you were (among a bunch of other things, usually dropping variables
+     * in the global namespace) and if you were not, returned an error.
+     * Now, controllers do this at a class level, which is mostly nonsense
+     * and requires that the router directly serve an error page.
+     *
+     * @return string
+     * @TODO this whole thing should be factored out.
+     */
+    public function validate() {
+        $error  = null;
+        $player = Player::find(SessionFactory::getSession()->get('player_id'));
+
+        if ((!SessionFactory::getSession()->get('authenticated') || !$player) && static::PRIV) {
+            $error = 'log_in';
+        } elseif ($player && static::ALIVE) { // That page requires the player to be alive to view it
+            if (!$player->health()) {
+                $error = 'dead';
+            } else if ($player->hasStatus(FROZEN)) {
+                $error = 'frozen';
+            }
+        }
+
+        return $error;
+    }
+
+    public function renderDefaultError($error) {
+        return [
+            'template' => 'error.tpl',
+            'title'    => 'There is an obstacle to your progress...',
+            'parts'    => ['error' => $error],
+            'options'  => [],
+        ];
+    }
+}

--- a/deploy/lib/control/AccountController.php
+++ b/deploy/lib/control/AccountController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\DatabaseConnection;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\data\Account;
@@ -10,7 +11,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 /**
  * Handle updates for changing account password, changing account email and showing the account page
  */
-class AccountController {
+class AccountController extends AbstractController {
     const ALIVE = false;
     const PRIV  = true;
 

--- a/deploy/lib/control/ApiController.php
+++ b/deploy/lib/control/ApiController.php
@@ -1,13 +1,14 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\extensions\SessionFactory;
 use NinjaWars\core\data\DatabaseConnection;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\data\Message;
 use \PDO;
 
-class ApiController {
+class ApiController extends AbstractController {
     public function sendHeaders() {
         // Json P headers
         header('Content-Type: text/javascript; charset=utf8');

--- a/deploy/lib/control/AssistanceController.php
+++ b/deploy/lib/control/AssistanceController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use \Nmail;
 use NinjaWars\core\data\DatabaseConnection;
 use NinjaWars\core\extensions\NWTemplate;
@@ -8,7 +9,7 @@ use NinjaWars\core\extensions\NWTemplate;
 /**
  * Give assistance to players and proto-players who anonymous users
  */
-class AssistanceController{
+class AssistanceController extends AbstractController {
     const PRIV          = false;
     const ALIVE         = false;
 

--- a/deploy/lib/control/AttackController.php
+++ b/deploy/lib/control/AttackController.php
@@ -2,6 +2,7 @@
 namespace NinjaWars\core\control;
 
 use NinjaWars\core\control\AttackLegal;
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\control\Combat;
 use NinjaWars\core\data\GameLog;
 use NinjaWars\core\data\Skill;
@@ -9,7 +10,7 @@ use NinjaWars\core\data\Player;
 use NinjaWars\core\data\Event;
 use NinjaWars\core\extensions\SessionFactory;
 
-class AttackController {
+class AttackController extends AbstractController {
     const ALIVE = true;
     const PRIV  = true;
     const BASE_WRATH_REGAIN = 2;

--- a/deploy/lib/control/CasinoController.php
+++ b/deploy/lib/control/CasinoController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\data\Inventory;
 use NinjaWars\core\extensions\SessionFactory;
@@ -9,7 +10,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 /**
  * Handles all user commands for the in-game Casino
  */
-class CasinoController {
+class CasinoController extends AbstractController {
 	const PRIV      = false;
 	const ALIVE     = true;
 	const REWARD    = 'phosphor';

--- a/deploy/lib/control/ChatController.php
+++ b/deploy/lib/control/ChatController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Message;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\extensions\SessionFactory;
@@ -8,7 +9,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * The controller for effects of a village request and the default index display of the page
  */
-class ChatController {
+class ChatController extends AbstractController {
     const ALIVE         = false;
     const PRIV          = false;
     const DEFAULT_LIMIT = 200;

--- a/deploy/lib/control/ClanController.php
+++ b/deploy/lib/control/ClanController.php
@@ -2,6 +2,7 @@
 namespace NinjaWars\core\control;
 
 use NinjaWars\core\data\ClanFactory;
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Message;
 use NinjaWars\core\data\Clan;
 use NinjaWars\core\data\Player;
@@ -11,7 +12,7 @@ use NinjaWars\core\data\DatabaseConnection;
 /**
  * Controller for all actions involving clan
  */
-class ClanController { //extends Controller
+class ClanController extends AbstractController {
 	const CLAN_CREATOR_MIN_LEVEL = 20;
 	const ALIVE                  = false;
 	const PRIV                   = false;

--- a/deploy/lib/control/ConsiderController.php
+++ b/deploy/lib/control/ConsiderController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\data\DatabaseConnection;
 use NinjaWars\core\data\Player;
@@ -11,7 +12,7 @@ use \PDO;
 /**
  * Display ninja & monsters to potentially pick fights with
  */
-class ConsiderController {
+class ConsiderController extends AbstractController {
     const ALIVE       = false;
     const PRIV        = false;
     const ENEMY_LIMIT = 20;

--- a/deploy/lib/control/DojoController.php
+++ b/deploy/lib/control/DojoController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\data\Inventory;
 use NinjaWars\core\environment\RequestWrapper;
@@ -15,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
  * To change order of class change cycling: Update $class_array, key = starting
  * class, value = next class in cycle
  */
-class DojoController {
+class DojoController extends AbstractController {
     const ALIVE                = false;
     const PRIV                 = false;
     const DIM_MAK_COST         = 70; // Cost of acquiring DimMak In turns

--- a/deploy/lib/control/DoshinController.php
+++ b/deploy/lib/control/DoshinController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\data\Event;
 use NinjaWars\core\extensions\SessionFactory;
@@ -8,7 +9,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Handles all user requests for the in-game Doshin Office
  */
-class DoshinController { //extends controller
+class DoshinController extends AbstractController {
     const ALIVE          = true;
     const PRIV           = false;
     const MAX_BOUNTY     = 5000;

--- a/deploy/lib/control/ErrorController.php
+++ b/deploy/lib/control/ErrorController.php
@@ -1,11 +1,12 @@
 <?php
-
 namespace NinjaWars\core\control;
+
+use NinjaWars\core\control\AbstractController;
 
 /**
  * Testing errors so that they return the right statuses if needed.
  */
-class ErrorController{
+class ErrorController extends AbstractController {
     const PRIV          = false;
     const ALIVE         = false;
     public function index(){

--- a/deploy/lib/control/EventsController.php
+++ b/deploy/lib/control/EventsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\DatabaseConnection;
 use NinjaWars\core\data\ClanFactory;
 use NinjaWars\core\data\Player;
@@ -9,7 +10,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Handle the listing of events
  */
-class EventsController {
+class EventsController extends AbstractController {
     const ALIVE = false;
     const PRIV  = true;
 

--- a/deploy/lib/control/HomepageController.php
+++ b/deploy/lib/control/HomepageController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Message;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\extensions\SessionFactory;
@@ -8,7 +9,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * display the standard homepage, and maybe eventually the splash page
  */
-class HomepageController {
+class HomepageController extends AbstractController {
     const PRIV      = false;
     const ALIVE     = false;
     private $loggedIn = false;

--- a/deploy/lib/control/InventoryController.php
+++ b/deploy/lib/control/InventoryController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\data\Item;
 use NinjaWars\core\data\Inventory;
@@ -13,7 +14,7 @@ use \PDO;
 /**
  * Control the display of items and gold (and maybe some day armor) for a char
  */
-class InventoryController {
+class InventoryController extends AbstractController {
 	const PRIV          = true;
 	const ALIVE         = false;
     const GIVE_COST     = 1;

--- a/deploy/lib/control/ListController.php
+++ b/deploy/lib/control/ListController.php
@@ -1,13 +1,14 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\extensions\SessionFactory;
 use NinjaWars\core\data\Player;
 
 /**
  * Display the ninja list as a whole
  */
-class ListController {
+class ListController extends AbstractController {
     const ALIVE = false;
     const PRIV  = false;
 

--- a/deploy/lib/control/LoginController.php
+++ b/deploy/lib/control/LoginController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Account;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\environment\RequestWrapper;
@@ -11,7 +12,7 @@ use \PDO;
 
 /**
  */
-class LoginController {
+class LoginController extends AbstractController {
     const ALIVE = false;
     const PRIV  = false;
 

--- a/deploy/lib/control/LogoutController.php
+++ b/deploy/lib/control/LogoutController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\extensions\SessionFactory;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use \Constants;
@@ -8,7 +9,7 @@ use \Constants;
 /**
  * Log a player out via post, then redirect to logout landing page
  */
-class LogoutController {
+class LogoutController extends AbstractController {
     const ALIVE = false;
     const PRIV  = false;
 

--- a/deploy/lib/control/MapController.php
+++ b/deploy/lib/control/MapController.php
@@ -1,8 +1,9 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 
-class MapController {
+class MapController extends AbstractController {
     const PRIV  = false;
     const ALIVE = false;
 

--- a/deploy/lib/control/MessagesController.php
+++ b/deploy/lib/control/MessagesController.php
@@ -1,13 +1,14 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Message;
 use NinjaWars\core\data\ClanFactory;
 use NinjaWars\core\data\Player;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\extensions\SessionFactory;
 
-class MessagesController {
+class MessagesController extends AbstractController {
     const PRIV  = true;
     const ALIVE = false;
 

--- a/deploy/lib/control/NewsController.php
+++ b/deploy/lib/control/NewsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use \model\News as News;
 use \model\Base;
 use \InvalidArgumentException;
@@ -13,7 +14,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Allows creation of news and displaying of news by admins
  */
-class NewsController {
+class NewsController extends AbstractController {
     const ALIVE = false;
     const PRIV  = false;
 

--- a/deploy/lib/control/NinjamasterController.php
+++ b/deploy/lib/control/NinjamasterController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\data\NpcFactory;
 use NinjaWars\core\data\AdminViews;
@@ -11,7 +12,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * The ninjamaster/admin info
  */
-class NinjamasterController {
+class NinjamasterController extends AbstractController {
     const ALIVE = false;
     const PRIV  = false;
     protected $charId = null;

--- a/deploy/lib/control/NpcController.php
+++ b/deploy/lib/control/NpcController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Npc;
 use NinjaWars\core\control\Combat;
 use NinjaWars\core\data\NpcFactory;
@@ -13,7 +14,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Handles displaying npcs and attacking specific npcs
  */
-class NpcController { //extends controller
+class NpcController extends AbstractController {
     const ALIVE                      = true;
     const PRIV                       = false;
     const HIGH_TURNS                 = 50;

--- a/deploy/lib/control/PasswordController.php
+++ b/deploy/lib/control/PasswordController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\environment\RequestWrapper;
 use NinjaWars\core\extensions\NWTemplate;
 use NinjaWars\core\data\PasswordResetRequest;
@@ -9,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use \Nmail;
 
-class PasswordController {
+class PasswordController extends AbstractController {
     const PRIV           = false;
     const ALIVE          = false;
 

--- a/deploy/lib/control/PlayerController.php
+++ b/deploy/lib/control/PlayerController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\control\AttackLegal;
 use NinjaWars\core\data\Message;
@@ -11,7 +12,7 @@ use NinjaWars\core\data\Account;
 use NinjaWars\core\data\Inventory;
 use NinjaWars\core\extensions\SessionFactory;
 
-class PlayerController {
+class PlayerController extends AbstractController {
     const PRIV  = false;
     const ALIVE = false;
 

--- a/deploy/lib/control/QuestController.php
+++ b/deploy/lib/control/QuestController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\extensions\SessionFactory;
 use \RuntimeException;
 
@@ -58,7 +59,7 @@ function get_questors($quest_id){
 /**
  * Get player quests, accept, and view individual ones, etc.
  */
-class QuestController {
+class QuestController extends AbstractController {
     const ALIVE = false;
     const PRIV  = false;
 

--- a/deploy/lib/control/RumorController.php
+++ b/deploy/lib/control/RumorController.php
@@ -1,11 +1,13 @@
 <?php
 namespace NinjaWars\core\control;
+
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\DatabaseConnection;
 
 /**
  * Handles the rumors and info displayed by the bathhouse.
  */
-class RumorController {
+class RumorController extends AbstractController {
     const ALIVE          = false;
     const PRIV           = false;
 

--- a/deploy/lib/control/ShopController.php
+++ b/deploy/lib/control/ShopController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Item;
 use NinjaWars\core\data\PurchaseOrder;
 use NinjaWars\core\data\Player;
@@ -10,7 +11,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Handles all user actions related to the in-game Shop
  */
-class ShopController { // extends Controller
+class ShopController extends AbstractController {
 	const ALIVE = true;  // *** must be alive to access the shop ***
 	const PRIV  = false; // *** do not need to be logged in ***
 

--- a/deploy/lib/control/ShrineController.php
+++ b/deploy/lib/control/ShrineController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Skill;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\extensions\SessionFactory;
@@ -8,7 +9,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Controller for actions taken in the Healing Shrine
  */
-class ShrineController { //extends controller
+class ShrineController extends AbstractController {
 	const ALIVE                = false;
 	const PRIV                 = true;
 	const FREE_RES_LEVEL_LIMIT = 6;

--- a/deploy/lib/control/SignupController.php
+++ b/deploy/lib/control/SignupController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Account;
 use NinjaWars\core\data\Player;
 use NinjaWars\core\environment\RequestWrapper;
@@ -17,7 +18,7 @@ use \Nmail;
  * email confirmation requirements and creating a one-button ninja creation
  * system.
  */
-class SignupController {
+class SignupController extends AbstractController {
     const ALIVE    = false;
     const PRIV     = false;
     const TEMPLATE = 'signup.tpl';

--- a/deploy/lib/control/SkillController.php
+++ b/deploy/lib/control/SkillController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\environment\RequestWrapper;
 use NinjaWars\core\data\Skill;
@@ -12,7 +13,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Handles both skill listing and displaying, and their usage
  */
-class SkillController {
+class SkillController extends AbstractController {
 	const ALIVE = true;
 	const PRIV  = true;
 

--- a/deploy/lib/control/StatsController.php
+++ b/deploy/lib/control/StatsController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\data\DatabaseConnection;
 use NinjaWars\core\data\ClanFactory;
@@ -11,7 +12,7 @@ use NinjaWars\core\extensions\SessionFactory;
 /**
  * Handle updates for changing details and profile details
  */
-class StatsController {
+class StatsController extends AbstractController {
 	const ALIVE = false;
 	const PRIV  = true;
 

--- a/deploy/lib/control/WorkController.php
+++ b/deploy/lib/control/WorkController.php
@@ -1,6 +1,7 @@
 <?php
 namespace NinjaWars\core\control;
 
+use NinjaWars\core\control\AbstractController;
 use NinjaWars\core\data\Player;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use NinjaWars\core\extensions\SessionFactory;
@@ -9,7 +10,7 @@ use NinjaWars\core\extensions\SessionFactory;
  * The controller for effects of a work request and the default index display
  * of the page and initial form
  */
-class WorkController {
+class WorkController extends AbstractController {
     const ALIVE = true;
     const PRIV  = false;
 

--- a/deploy/www/front-controller.php
+++ b/deploy/www/front-controller.php
@@ -14,7 +14,13 @@ try {
     update_activity_info(); // Updates the activity of the page viewer in the database.
 
     // get the request information to parse the route
-    Router::route(Request::createFromGlobals());
+    $response = Router::route(Request::createFromGlobals());
+
+    if ($response instanceof RedirectResponse) {
+        $response->send();
+    } else {
+        Router::render($response);
+    }
 } catch (RouteNotFoundException $e) {
     Router::respond404();
 }

--- a/deploy/www/front-controller.php
+++ b/deploy/www/front-controller.php
@@ -1,9 +1,10 @@
 <?php
 require_once(dirname(__DIR__.'..').'/lib/base.inc.php');
 
-use NinjaWars\core\Router;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use NinjaWars\core\RouteNotFoundException;
+use NinjaWars\core\Router;
 
 if (defined('TRAP_ERRORS') && TRAP_ERRORS) {
     set_exception_handler(['NWError', 'exceptionHandler']);
@@ -16,10 +17,12 @@ try {
     // get the request information to parse the route
     $response = Router::route(Request::createFromGlobals());
 
-    if ($response instanceof RedirectResponse) {
+    if ($response instanceof Response) {
         $response->send();
-    } else {
+    } else if (is_array($response)) {
         Router::render($response);
+    } else {
+        echo $response;
     }
 } catch (RouteNotFoundException $e) {
     Router::respond404();


### PR DESCRIPTION
resolve #705 
resolve #703 

Router no longer understands Responses and instead passes the output of the Controller to the front-controller. The front-controller tests if it's a Response (Redirect or otherwise) to send() it, if it's an array to Router::render() it, or if it's a string to simply echo it. Eventually, Router::render() will be replaced with Responses, as will the echo.

In addition, an abstract controller was added to handle checking private and alive. Router calls validate() then calls renderDefaultError() if validate() returns a string. Otherwise, it returns the result of calling the $action on the $controller. Could probably continue to improve this (throw exceptions in validate() for example) but this should do for now.