### PR TITLE
Cleanup attack

### DIFF
--- a/deploy/lib/control/AttackController.php
+++ b/deploy/lib/control/AttackController.php
@@ -13,39 +13,44 @@ use NinjaWars\core\extensions\StreamedViewResponse;
 use NinjaWars\core\environment\RequestWrapper;
 
 class AttackController extends AbstractController {
-    const ALIVE = true;
-    const PRIV  = true;
-    const BASE_WRATH_REGAIN = 2;
-    const DEFAULT_GOLD_MOD  = 0.2;
-    const DUEL_GOLD_MOD     = 0.25;
+    const ALIVE                  = true;
+    const PRIV                   = true;
+    const BASE_WRATH_REGAIN      = 2;
+    const DEFAULT_GOLD_MOD       = 0.2;
+    const DUEL_GOLD_MOD          = 0.25;
+    const STEALTH_GOLD_MOD       = 0.1;
+    const STEALTH_STRIKE_COST    = 1;
+    const EVEN_MATCH_KI_REWARD   = 1;
+    const EVEN_MATCH_ROUND_COUNT = 4;
 
     /**
      * @return Response
      */
     public function index() {
         $request = RequestWrapper::$request;
+        $session = SessionFactory::getSession();
 
         $duel    = (bool) $request->get('duel');
         $blaze   = (bool) $request->get('blaze');
         $deflect = (bool) $request->get('deflect');
         $evade   = (bool) $request->get('evasion');
 
-        // Template vars.
-        $stealthed_attack = $stealth_damage = $stealth_lost =
-            $pre_battle_stats = $rounds = $combat_final_results =
-            $killed_target = $attacker_died = $bounty_result = $rewarded_ki =
-            $wrath_regain = false;
-
-        $killpoints       = 0; // Starting state for killpoints
-        $attack_turns     = 1; // Default cost, will go to zero if an error prevents combat
-        $required_turns   = 0;
-        $loot             = 0;
-        $simultaneousKill = NULL; // Not simultaneous by default
-        $turns_to_take    = NULL; // Even on failure take at least one turn
-        $attack_type      = [];
-        $attack_again     = false;
-        $victor           = null;
-        $loser            = null;
+        $stealthed_attack     = false;
+        $stealth_damage       = false;
+        $stealth_lost         = false;
+        $rounds               = false;
+        $bounty_result        = false;
+        $rewarded_ki          = false;
+        $attack_again         = false;
+        $wrath                = false;
+        $attack_turns         = 1;
+        $required_turns       = 0;
+        $turns_to_take        = 0;
+        $loot                 = 0;
+        $killpoints           = 1;
+        $attack_type          = [];
+        $victor               = null;
+        $loser                = null;
 
         if ($blaze) {
             $attack_type['blaze'] = 'blaze';
@@ -66,7 +71,7 @@ class AttackController extends AbstractController {
         }
 
         $target   = Player::find($request->get('target'));
-        $attacker = Player::find(SessionFactory::getSession()->get('player_id'));
+        $attacker = Player::find($session->get('player_id'));
 
         $skillListObj = new Skill();
 
@@ -77,7 +82,6 @@ class AttackController extends AbstractController {
             $required_turns += $skillListObj->getTurnCost($type);
         }
 
-        // *** Attack Legal section ***
         $params = [
             'required_turns'  => $required_turns,
             'ignores_stealth' => $ignores_stealth,
@@ -92,229 +96,221 @@ class AttackController extends AbstractController {
             $attack_error    = 'Could not determine valid target';
         }
 
-        // ***  MAIN BATTLE ALGORITHM  ***
         if ($attack_is_legal) {
-            if (!$duel && $attacker->hasStatus(STEALTH)) { // *** Not dueling, and attacking from stealth ***
-                // TODO: This area seems to be the area that contains the broken stealth-kill-without-reporting bug
-                // https://github.com/BitLucid/ninjawars/issues/273
-                $stealthAttackDamage = $attacker->getStrength();
+            $starting_attacker = clone $attacker;
+            $starting_target   = clone $target;
+
+            $turns_counter = ($duel ? -1 : $attack_turns);
+            $rounds        = 0;
+
+            $attacker_label = $attacker->name();
+
+            if (!$duel && $attacker->hasStatus(STEALTH)) {
                 $stealthed_attack = true;
-                $target->harm($stealthAttackDamage);
+                $this->stealthStrike($attacker, $target);
 
-                $attacker->subtractStatus(STEALTH);
-                $turns_to_take = 1;
+                $gold_mod = self::STEALTH_GOLD_MOD;
 
-                if (0 > $target->health) { // *** if Stealth attack of whatever damage kills target. ***
-                    $victor       = $attacker;
-                    $loser        = $target;
-                    $gold_mod     = .1;
-                    $loot         = floor($gold_mod * $target->gold);
-                    $target_msg   = "DEATH: You have been killed by a stealthed ninja in combat and lost $loot gold!";
-                    $attacker_msg = "You have killed {$target->name()} in combat and taken $loot gold.";
-
-                    $target->death();
-                    Event::create((int)"A Stealthed Ninja", $target->id(), $target_msg);
-                    Event::create($target->id(), $attacker->id(), $attacker_msg);
-                    $bounty_result = Combat::runBountyExchange($attacker, $target); // *** Determines the bounty for normal attacking. ***
-
-                    $stealth_kill = true;
-                } else {	// *** if damage from stealth only hurts the target. ***
+                if ($target->health > 0) {
                     $stealth_damage = true;
-
-                    Event::create($attacker->id(), $target->id(), $attacker->name()." has attacked you from the shadows for $stealthAttackDamage damage.");
+                } else {
+                    $attacker_label = 'a stealthed ninja';
+                    $victor = $attacker;
+                    $loser  = $target;
                 }
-            } else {	// *** If the attacker is purely dueling or attacking, even if stealthed, though stealth is broken by dueling. ***
-                // *** MAIN DUELING SECTION ***
-                if ($attacker->hasStatus(STEALTH)) { // *** Remove their stealth if they duel instead of preventing dueling.
-                    $attacker->subtractStatus(STEALTH);
+
+                $attack_label = "attacked %s from the shadows";
+            } else {
+                $gold_mod = ($duel ? self::DUEL_GOLD_MOD : self::DEFAULT_GOLD_MOD);
+
+                if ($attacker->hasStatus(STEALTH)) {
                     $stealth_lost = true;
                 }
 
-                // *** PRE-BATTLE STATS - Template Vars ***
-                $pre_battle_stats  = true;
-                $pbs_attacker_str  = $attacker->getStrength();
-                $pbs_attacker_hp   = $attacker->health();
-                $pbs_target_str    = $target->getStrength();
-                $pbs_target_hp     = $target->health();
+                $attacker->subtractStatus(STEALTH);
 
-                // *** BEGINNING OF MAIN BATTLE ALGORITHM ***
+                while ($turns_counter != 0 && $attacker->health > 0 && $target->health > 0) {
+                    $turns_counter--;
+                    $rounds++;
 
-                $turns_counter         = $attack_turns;
-                $total_target_damage   = 0;
-                $total_attacker_damage = 0;
-                $target_damage         = 0;
-                $attacker_damage       = 0;
+                    $this->strike($attacker, $target, $blaze, $deflect);
 
-                // *** Combat Calculations ***
-                $round = 1;
-                $rounds = 0;
-
-                while ($turns_counter > 0 && $attacker->health > 0 && $target->health > 0) {
-                    $turns_counter -= (!$duel ? 1 : 0);// *** SWITCH BETWEEN DUELING LOOP AND SINGLE ATTACK ***
-
-                    $target_damage   = rand(1, $target->getStrength());
-                    $attacker_damage = rand(1, $attacker->getStrength());
-
-                    if ($blaze) {	// *** Blaze does double damage. ***
-                        $attacker_damage = $attacker_damage*2;
-                    }
-
-                    if ($deflect) {
-                        $target_damage = floor($target_damage/2);
-                    }
-
-                    $total_target_damage   += $target_damage;
-                    $total_attacker_damage += $attacker_damage;
-
-                    $target->harm($attacker_damage);
-                    $attacker->harm($target_damage);
-
-                    $rounds++;	// *** Increases the number of rounds that has occured and restarts the while loop. ***
-
-                    if ($evade) {
-                        // Evasion effect:
-                        // Check current level of damage.
-                        $testValue = ($attacker->health - $total_target_damage);
-                        // Break off the duel/attack if less than 10% health or health is less than average of defender's strength
-                        if ($testValue < ($target->getStrength()*.5) || $testValue < ($attacker->health*.1)) {
-                            break;
-                        }
+                    /**
+                     * Evasion effect:
+                     *
+                     * Break off the duel/attack if less than 10% health or
+                     * health is less than average of defender's strength
+                     */
+                    if ($evade && (
+                        $attacker->health < ($target->getStrength()*.5) ||
+                        $attacker->health < ($attacker->health*.1))
+                    ) {
+                        break;
                     }
                 }
 
-                // *** END OF MAIN BATTLE ALGORITHM ***
+                $attacker->changeTurns(-1*$required_turns);
 
-                $combat_final_results = true;
-                $finalizedHealth = ($attacker->health);
-
-                // *** RESULTING PLAYER MODIFICATION ***
-
-                $gold_mod = ($duel ? self::DUEL_GOLD_MOD : self::DEFAULT_GOLD_MOD);
-
-                $turns_to_take = $required_turns;
-
-                //  *** Let the victim know who hit them ***
-                $attack_label = ($duel ? 'dueled' : 'attacked');
-
-                if ($target->health && $attacker->health) {
-                    $combat_msg = "You have been $attack_label by {$attacker->name()} for $total_attacker_damage, but they got away before you could kill them!";
-                } else {
-                    $combat_msg = "You have been $attack_label by {$attacker->name()} for $total_attacker_damage!";
-                }
-
-                Event::create($attacker->id(), $target->id(), $combat_msg);
-
-                if ($target->health < 1 || $attacker->health < 1) { // A kill occurred.
-                    if ($target->health < 1) { // ATTACKER KILLS DEFENDER!
-                        $simultaneousKill = ($attacker->health < 1);
-
-                        if (!$simultaneousKill) {
-                            $victor = $attacker;
-                            $loser  = $target;
-                        }
-
-                        $killed_target = true;
-
-                        $killpoints = 1; // Changes killpoints from zero to one.
-
-                        if ($duel) {
-                            // Changes killpoints amount by dueling equation.
-                            $killpoints = Combat::killpointsFromDueling($attacker, $target);
-
-                            $duel_log_msg = $attacker->name()." has dueled {$target->name()} and won $killpoints killpoints.";
-
-                            // Only log duels if they're better than 1 or if they're a failure.
-                            if ($killpoints > 1 || $killpoints < 0) {
-                                // Make a WIN record in the dueling log.
-                                GameLog::sendLogOfDuel($attacker->name(), $target->name(), 1, $killpoints);
-                            }
-
-                            if ($skillListObj->hasSkill('wrath', $attacker)) {
-                                // They'll retain 10 health for the kill, at the end.
-                                $wrath_regain = self::BASE_WRATH_REGAIN;
-                            }
-                        }
-
-                        $attacker->addKills($killpoints); // Attacker gains their killpoints.
-                        $target->death();
-
-                        if (!$simultaneousKill)	{
-                            // This stuff only happens if you don't die also.
-                            $loot = floor($gold_mod * $target->gold);
-
-                            // Add the wrath health regain to the attacker.
-                            if (isset($wrath_regain)) {
-                                $attacker->heal($wrath_regain);
-                            }
-                        }
-
-                        $target_msg = "DEATH: You've been killed by {$attacker->name()} and lost $loot gold!";
-                        Event::create($attacker->id(), $target->id(), $target_msg);
-                        // Stopped telling attackers when they win a duel.
-
-                        $bounty_result = Combat::runBountyExchange($attacker, $target);	// *** Determines bounty for dueling. ***
-                    }
-
-                    if ($attacker->health < 1) { // *** DEFENDER KILLS ATTACKER! ***
-                        $simultaneousKill = ($target->health < 1);
-
-                        if (!$simultaneousKill)	{
-                            $victor = $target;
-                            $loser  = $attacker;
-                        }
-
-                        $attacker_died = true;
-
-                        $defenderKillpoints = 1;
-
-                        if ($duel) { // *** if they were dueling when they died ***
-                            $duel_log_msg = $attacker->name()." has dueled {$target->name()} and lost at ".date("F j, Y, g:i a");
-                            Event::create((int)"SysMsg", (int)"SysMsg", $duel_log_msg);
-                            GameLog::sendLogOfDuel($attacker->name(), $target->name(), 0, $killpoints);	// *** Makes a loss in the duel log. ***
-                        }
-
-                        $target->addKills($defenderKillpoints); // Adds a kill for the defender
-                        $attacker->death();
-
-                        if (!$simultaneousKill) {
-                            $loot = floor($gold_mod * $attacker->gold); //Loot for defender if he lives.
-                        }
-
-                        $target_msg = "You have killed {$attacker->name()} in combat and taken $loot gold.";
-
-                        $attacker_msg = "DEATH: You've been killed by {$target->name()} and lost $loot gold!";
-
-                        Event::create($attacker->id(), $target->id(), $target_msg);
-                        Event::create($target->id(), $attacker->id(), $attacker_msg);
-                    }
-                }
+                $attack_label = ($duel ? 'dueled %s' : 'attacked %s');
             }
 
-            if ($loot) {
-                $victor->set_gold($victor->gold + $loot);
-                $loser->set_gold($loser->gold - $loot);
+            if ($target->health > 0 && $attacker->health > 0) {
+                $combat_msg = "%s $attack_label for %s damage, but they got away before you could kill them!";
+
+                Event::create(
+                    $attacker->id(),
+                    $target->id(),
+                    sprintf(
+                        $combat_msg,
+                        $attacker->name(),
+                        'you',
+                        ($starting_target->health - $target->health)
+                    )
+                );
+
+                if ($attacker->hasStatus(STEALTH)) {
+                    $stealth_lost = true;
+                }
+
+                $attacker->subtractStatus(STEALTH);
+            } else if ($target->health < 1 && $attacker->health < 1) {
+                $loot = 0;
+                $this->win($attacker, $target, $loot, $killpoints);
+                $this->win($target, $attacker, $loot, 1);
+                $this->lose($attacker, $target, $loot);
+                $this->lose($target, $attacker, $loot);
+            } else if ($target->health < 1) {
+                $victor        = $attacker;
+                $loser         = $target;
+                $bounty_result = Combat::runBountyExchange($victor, $loser);
+                $loot          = floor($gold_mod * $loser->gold);
+
+                if ($duel) {
+                    $killpoints = Combat::killpointsFromDueling($attacker, $target);
+
+                    if ($skillListObj->hasSkill('wrath', $attacker)) {
+                        // They'll regain some health for the kill, at the end.
+                        $attacker->heal(self::BASE_WRATH_REGAIN);
+                        $wrath = true;
+                    }
+                }
+
+                $reporting_victor = $victor;
+
+                if ($victor->hasStatus(STEALTH)) {
+                    $reporting_victor = new Player();
+                    $reporting_victor->uname     = 'a stealthed ninja';
+                    $reporting_victor->player_id = 0;
+                }
+
+                $this->lose($loser, $reporting_victor, $loot);
+                $this->win($victor, $loser, $loot, $killpoints);
+            } else {
+                $victor = $target;
+                $loser  = $attacker;
+                $loot   = floor($gold_mod * $loser->gold);
+
+                $this->lose($loser, $victor, $loot);
+                $this->win($victor, $loser, $loot, $killpoints);
             }
 
-            if ($rounds > 4) { // Evenly matched battle! Reward some ki to the attacker, even if they die
-                $rewarded_ki = 1;
+            if ($duel) {
+                $this->logDuel($attacker, $target, $victor, $killpoints);
+            }
+
+            if ($rounds > self::EVEN_MATCH_ROUND_COUNT) { // Evenly matched battle! Reward some ki to the attacker, even if they die
+                $rewarded_ki = self::EVEN_MATCH_KI_REWARD;
 
                 $attacker->set_ki($attacker->ki + $rewarded_ki);
             }
 
-            $attack_again = (isset($target) && $attacker->health() > 0 && $target->health() > 0);
+            $attack_again = (isset($target) && $attacker->health > 0 && $target->health > 0);
 
-            $target_ending_health = $target->health();
             $target->save();
+        } else {
+            // Take away at least one turn even on attacks that fail.
+            $attacker->changeTurns(-1);
         }
 
-        // *** Take away at least one turn even on attacks that fail. ***
-        if ($turns_to_take < 1) {
-            $turns_to_take = 1;
-        }
-
-        $attacker->changeTurns(-1*$turns_to_take);
         $attacker->save();
 
         return new StreamedViewResponse('Battle Status', 'attack_mod.tpl', get_defined_vars(), ['quickstat' => 'player' ]);
+    }
+
+    /**
+     * @return void
+     */
+    private function stealthStrike(Player $attacker, Player $target) {
+        $target->harm($attacker->getStrength());
+        $attacker->changeTurns(-1*self::STEALTH_STRIKE_COST);
+    }
+
+    /**
+     * @return void
+     */
+    private function strike($attacker, $target, $blaze, $deflect) {
+        $target_damage   = rand(1, $target->getStrength());
+        $attacker_damage = rand(1, $attacker->getStrength());
+
+        if ($blaze) {
+            $attacker_damage = $attacker_damage*2;
+        }
+
+        if ($deflect) {
+            $target_damage = floor($target_damage/2);
+        }
+
+        $target->harm($attacker_damage);
+        $attacker->harm($target_damage);
+    }
+
+    /**
+     * @return void
+     */
+    private function lose($loser, $victor, $loot) {
+        $loser->set_gold($loser->gold - $loot);
+        $loser->death();
+
+        $loser_msg = "DEATH: You have been killed by {$victor->name()} in combat and lost $loot gold!";
+        Event::create($victor->id(), $loser->id(), $loser_msg);
+    }
+
+    /**
+     * @return void
+     */
+    private function win($victor, $loser, $loot, $killpoints) {
+        $victor_msg = "You have killed {$loser->name()} in combat and taken $loot gold.";
+        Event::create($loser->id(), $victor->id(), $victor_msg);
+        $victor->set_gold($victor->gold + $loot);
+        $victor->addKills($killpoints);
+    }
+
+    /**
+     * @return void
+     */
+    private function logDuel($attacker, $target, $winner, $killpoints) {
+        $duel_log_msg = "%s has dueled {$target->name()} and ";
+
+        if ($attacker !== $winner) {
+            $duel_log_msg .= "lost at ".date("F j, Y, g:i a");
+        } else if ($killpoints > 1 || $killpoints < 0) {
+            $duel_log_msg .= "won $killpoints killpoints.";
+        } else {
+            $duel_log_msg = '';
+        }
+
+        if ($duel_log_msg !== '') {
+            Event::create(
+                (int)"SysMsg",
+                (int)"SysMsg",
+                sprintf(
+                    $duel_log_msg,
+                    $attacker->name(),
+                    $target->name()
+                )
+            );
+
+            GameLog::sendLogOfDuel($attacker->name(), $target->name(), $attacker === $winner, $killpoints);
+        }
     }
 }

--- a/deploy/lib/control/AttackController.php
+++ b/deploy/lib/control/AttackController.php
@@ -86,7 +86,7 @@ class AttackController extends AbstractController {
      * @return StreamedViewResponse
      */
     private function combat(Player $attacker, Player $target, $required_turns, $options) {
-        $attack_error      = false;
+        $error             = '';
         $stealthed_attack  = false;
         $stealth_damage    = false;
         $stealth_lost      = false;

--- a/deploy/lib/control/AttackController.php
+++ b/deploy/lib/control/AttackController.php
@@ -16,13 +16,15 @@ class AttackController extends AbstractController {
     const ALIVE = true;
     const PRIV  = true;
     const BASE_WRATH_REGAIN = 2;
+    const DEFAULT_GOLD_MOD  = 0.2;
+    const DUEL_GOLD_MOD     = 0.25;
 
     /**
      * @return Response
      */
     public function index() {
         $request = RequestWrapper::$request;
-        $target  = $request->get('target');
+
         $duel    = (bool) $request->get('duel');
         $blaze   = (bool) $request->get('blaze');
         $deflect = (bool) $request->get('deflect');
@@ -34,16 +36,16 @@ class AttackController extends AbstractController {
             $killed_target = $attacker_died = $bounty_result = $rewarded_ki =
             $wrath_regain = false;
 
-        // *** Attack System Initialization ***
         $killpoints       = 0; // Starting state for killpoints
         $attack_turns     = 1; // Default cost, will go to zero if an error prevents combat
         $required_turns   = 0;
-        $what             = ''; // This will be the attack type string, e.g. "duel"
         $loot             = 0;
         $simultaneousKill = NULL; // Not simultaneous by default
         $turns_to_take    = NULL; // Even on failure take at least one turn
         $attack_type      = [];
         $attack_again     = false;
+        $victor           = null;
+        $loser            = null;
 
         if ($blaze) {
             $attack_type['blaze'] = 'blaze';
@@ -63,14 +65,14 @@ class AttackController extends AbstractController {
             $attack_type['attack'] = 'attack';
         }
 
-        $target_player    = Player::find($target);
-        $attacking_player = Player::find(SessionFactory::getSession()->get('player_id'));
+        $target   = Player::find($request->get('target'));
+        $attacker = Player::find(SessionFactory::getSession()->get('player_id'));
 
         $skillListObj = new Skill();
 
         $ignores_stealth = false;
 
-        foreach ($attack_type as $type) {
+        foreach ($attack_type as $type=>$value) {
             $ignores_stealth = $ignores_stealth||$skillListObj->getIgnoreStealth($type);
             $required_turns += $skillListObj->getTurnCost($type);
         }
@@ -82,80 +84,58 @@ class AttackController extends AbstractController {
         ];
 
         try {
-            $attack_legal = new AttackLegal($attacking_player, $target_player, $params);
+            $attack_legal    = new AttackLegal($attacker, $target, $params);
             $attack_is_legal = $attack_legal->check();
-            $attack_error = $attack_legal->getError();
+            $attack_error    = $attack_legal->getError();
         } catch (\InvalidArgumentException $e) {
             $attack_is_legal = false;
-            $attack_error = 'Could not determine valid target';
+            $attack_error    = 'Could not determine valid target';
         }
 
         // ***  MAIN BATTLE ALGORITHM  ***
         if ($attack_is_legal) {
-            // *** Target's stats. ***
-            $target_health = $target_player->health;
-            $target_level  = $target_player->level;
-            $target_str    = $target_player->getStrength();
-
-            // *** Attacker's stats. ***
-            $attacker_health = $attacking_player->health;
-            $attacker_level  = $attacking_player->level;
-            $attacker_turns  = $attacking_player->turns;
-            $attacker_str    = $attacking_player->getStrength();
-
-            $starting_target_health = $target_health;
-            $starting_turns         = $attacker_turns;
-            $stealthAttackDamage    = $attacker_str;
-            $level_check            = $attacker_level - $target_level;
-
-            $loot   = 0;
-            $victor = null;
-            $loser  = null;
-
-            // *** ATTACKING + STEALTHED SECTION  ***
-            if (!$duel && $attacking_player->hasStatus(STEALTH)) { // *** Not dueling, and attacking from stealth ***
+            if (!$duel && $attacker->hasStatus(STEALTH)) { // *** Not dueling, and attacking from stealth ***
                 // TODO: This area seems to be the area that contains the broken stealth-kill-without-reporting bug
                 // https://github.com/BitLucid/ninjawars/issues/273
-                $attacking_player->subtractStatus(STEALTH);
+                $stealthAttackDamage = $attacker->getStrength();
+                $stealthed_attack = true;
+                $target->harm($stealthAttackDamage);
+
+                $attacker->subtractStatus(STEALTH);
                 $turns_to_take = 1;
 
-                $stealthed_attack = true;
-                $target_health = $target_player->harm($stealthAttackDamage);
-
-                if (0 > $target_health) { // *** if Stealth attack of whatever damage kills target. ***
-                    $victor = $attacking_player;
-                    $loser  = $target_player;
-
+                if (0 > $target->health) { // *** if Stealth attack of whatever damage kills target. ***
+                    $victor       = $attacker;
+                    $loser        = $target;
                     $gold_mod     = .1;
-                    $loot         = floor($gold_mod * $target_player->gold);
-
+                    $loot         = floor($gold_mod * $target->gold);
                     $target_msg   = "DEATH: You have been killed by a stealthed ninja in combat and lost $loot gold!";
-                    $attacker_msg = "You have killed {$target_player->name()} in combat and taken $loot gold.";
+                    $attacker_msg = "You have killed {$target->name()} in combat and taken $loot gold.";
 
-                    $target_player->death();
-                    Event::create((int)"A Stealthed Ninja", $target_player->id(), $target_msg);
-                    Event::create($target_player->id(), $attacking_player->id(), $attacker_msg);
-                    $bounty_result = Combat::runBountyExchange($attacking_player, $target_player); // *** Determines the bounty for normal attacking. ***
+                    $target->death();
+                    Event::create((int)"A Stealthed Ninja", $target->id(), $target_msg);
+                    Event::create($target->id(), $attacker->id(), $attacker_msg);
+                    $bounty_result = Combat::runBountyExchange($attacker, $target); // *** Determines the bounty for normal attacking. ***
 
                     $stealth_kill = true;
                 } else {	// *** if damage from stealth only hurts the target. ***
                     $stealth_damage = true;
 
-                    Event::create($attacking_player->id(), $target_player->id(), $attacking_player->name()." has attacked you from the shadows for $stealthAttackDamage damage.");
+                    Event::create($attacker->id(), $target->id(), $attacker->name()." has attacked you from the shadows for $stealthAttackDamage damage.");
                 }
             } else {	// *** If the attacker is purely dueling or attacking, even if stealthed, though stealth is broken by dueling. ***
                 // *** MAIN DUELING SECTION ***
-                if ($attacking_player->hasStatus(STEALTH)) { // *** Remove their stealth if they duel instead of preventing dueling.
-                    $attacking_player->subtractStatus(STEALTH);
+                if ($attacker->hasStatus(STEALTH)) { // *** Remove their stealth if they duel instead of preventing dueling.
+                    $attacker->subtractStatus(STEALTH);
                     $stealth_lost = true;
                 }
 
                 // *** PRE-BATTLE STATS - Template Vars ***
                 $pre_battle_stats  = true;
-                $pbs_attacker_str  = $attacking_player->getStrength();
-                $pbs_attacker_hp   = $attacking_player->health();
-                $pbs_target_str    = $target_player->getStrength();
-                $pbs_target_hp     = $target_player->health();
+                $pbs_attacker_str  = $attacker->getStrength();
+                $pbs_attacker_hp   = $attacker->health();
+                $pbs_target_str    = $target->getStrength();
+                $pbs_target_hp     = $target->health();
 
                 // *** BEGINNING OF MAIN BATTLE ALGORITHM ***
 
@@ -169,11 +149,11 @@ class AttackController extends AbstractController {
                 $round = 1;
                 $rounds = 0;
 
-                while ($turns_counter > 0 && $total_target_damage < $attacker_health && $total_attacker_damage < $target_health) {
+                while ($turns_counter > 0 && $attacker->health > 0 && $target->health > 0) {
                     $turns_counter -= (!$duel ? 1 : 0);// *** SWITCH BETWEEN DUELING LOOP AND SINGLE ATTACK ***
 
-                    $target_damage   = rand (1, $target_str);
-                    $attacker_damage = rand (1, $attacker_str);
+                    $target_damage   = rand(1, $target->getStrength());
+                    $attacker_damage = rand(1, $attacker->getStrength());
 
                     if ($blaze) {	// *** Blaze does double damage. ***
                         $attacker_damage = $attacker_damage*2;
@@ -185,14 +165,18 @@ class AttackController extends AbstractController {
 
                     $total_target_damage   += $target_damage;
                     $total_attacker_damage += $attacker_damage;
+
+                    $target->harm($attacker_damage);
+                    $attacker->harm($target_damage);
+
                     $rounds++;	// *** Increases the number of rounds that has occured and restarts the while loop. ***
 
                     if ($evade) {
                         // Evasion effect:
                         // Check current level of damage.
-                        $testValue = ($attacker_health - $total_target_damage);
+                        $testValue = ($attacker->health - $total_target_damage);
                         // Break off the duel/attack if less than 10% health or health is less than average of defender's strength
-                        if ($testValue < ($target_str*.5) || $testValue < ($attacker_health*.1)) {
+                        if ($testValue < ($target->getStrength()*.5) || $testValue < ($attacker->health*.1)) {
                             break;
                         }
                     }
@@ -201,40 +185,32 @@ class AttackController extends AbstractController {
                 // *** END OF MAIN BATTLE ALGORITHM ***
 
                 $combat_final_results = true;
-                $finalizedHealth = ($attacker_health-$total_target_damage);
+                $finalizedHealth = ($attacker->health);
 
                 // *** RESULTING PLAYER MODIFICATION ***
 
-                $gold_mod = 0.20;
+                $gold_mod = ($duel ? self::DUEL_GOLD_MOD : self::DEFAULT_GOLD_MOD);
 
                 $turns_to_take = $required_turns;
-
-                if ($duel) {
-                    $gold_mod = 0.25;
-                    $what     = "duel";
-                }
 
                 //  *** Let the victim know who hit them ***
                 $attack_label = ($duel ? 'dueled' : 'attacked');
 
-                $defenderHealthRemaining = $target_player->harm($total_attacker_damage);
-                $attackerHealthRemaining = $attacking_player->harm($total_target_damage);
-
-                if ($defenderHealthRemaining && $attackerHealthRemaining) {
-                    $combat_msg = "You have been $attack_label by {$attacking_player->name()} for $total_attacker_damage, but they got away before you could kill them!";
+                if ($target->health && $attacker->health) {
+                    $combat_msg = "You have been $attack_label by {$attacker->name()} for $total_attacker_damage, but they got away before you could kill them!";
                 } else {
-                    $combat_msg = "You have been $attack_label by {$attacking_player->name()} for $total_attacker_damage!";
+                    $combat_msg = "You have been $attack_label by {$attacker->name()} for $total_attacker_damage!";
                 }
 
-                Event::create($attacking_player->id(), $target_player->id(), $combat_msg);
+                Event::create($attacker->id(), $target->id(), $combat_msg);
 
-                if ($defenderHealthRemaining < 1 || $attackerHealthRemaining < 1) { // A kill occurred.
-                    if ($defenderHealthRemaining < 1) { // ATTACKER KILLS DEFENDER!
-                        $simultaneousKill = ($attackerHealthRemaining < 1);
+                if ($target->health < 1 || $attacker->health < 1) { // A kill occurred.
+                    if ($target->health < 1) { // ATTACKER KILLS DEFENDER!
+                        $simultaneousKill = ($attacker->health < 1);
 
                         if (!$simultaneousKill) {
-                            $victor = $attacking_player;
-                            $loser  = $target_player;
+                            $victor = $attacker;
+                            $loser  = $target;
                         }
 
                         $killed_target = true;
@@ -243,48 +219,48 @@ class AttackController extends AbstractController {
 
                         if ($duel) {
                             // Changes killpoints amount by dueling equation.
-                            $killpoints = Combat::killpointsFromDueling($attacking_player, $target_player);
+                            $killpoints = Combat::killpointsFromDueling($attacker, $target);
 
-                            $duel_log_msg = $attacking_player->name()." has dueled {$target_player->name()} and won $killpoints killpoints.";
+                            $duel_log_msg = $attacker->name()." has dueled {$target->name()} and won $killpoints killpoints.";
 
                             // Only log duels if they're better than 1 or if they're a failure.
                             if ($killpoints > 1 || $killpoints < 0) {
                                 // Make a WIN record in the dueling log.
-                                GameLog::sendLogOfDuel($attacking_player->name(), $target_player->name(), 1, $killpoints);
+                                GameLog::sendLogOfDuel($attacker->name(), $target->name(), 1, $killpoints);
                             }
 
-                            if ($skillListObj->hasSkill('wrath', $attacking_player)) {
+                            if ($skillListObj->hasSkill('wrath', $attacker)) {
                                 // They'll retain 10 health for the kill, at the end.
                                 $wrath_regain = self::BASE_WRATH_REGAIN;
                             }
                         }
 
-                        $attacking_player->addKills($killpoints); // Attacker gains their killpoints.
-                        $target_player->death();
+                        $attacker->addKills($killpoints); // Attacker gains their killpoints.
+                        $target->death();
 
                         if (!$simultaneousKill)	{
                             // This stuff only happens if you don't die also.
-                            $loot = floor($gold_mod * $target_player->gold);
+                            $loot = floor($gold_mod * $target->gold);
 
                             // Add the wrath health regain to the attacker.
                             if (isset($wrath_regain)) {
-                                $attacking_player->heal($wrath_regain);
+                                $attacker->heal($wrath_regain);
                             }
                         }
 
-                        $target_msg = "DEATH: You've been killed by {$attacking_player->name()} and lost $loot gold!";
-                        Event::create($attacking_player->id(), $target_player->id(), $target_msg);
+                        $target_msg = "DEATH: You've been killed by {$attacker->name()} and lost $loot gold!";
+                        Event::create($attacker->id(), $target->id(), $target_msg);
                         // Stopped telling attackers when they win a duel.
 
-                        $bounty_result = Combat::runBountyExchange($attacking_player, $target_player);	// *** Determines bounty for dueling. ***
+                        $bounty_result = Combat::runBountyExchange($attacker, $target);	// *** Determines bounty for dueling. ***
                     }
 
-                    if ($attackerHealthRemaining < 1) { // *** DEFENDER KILLS ATTACKER! ***
-                        $simultaneousKill = ($attackerHealthRemaining < 1);
+                    if ($attacker->health < 1) { // *** DEFENDER KILLS ATTACKER! ***
+                        $simultaneousKill = ($target->health < 1);
 
                         if (!$simultaneousKill)	{
-                            $victor = $target_player;
-                            $loser  = $attacking_player;
+                            $victor = $target;
+                            $loser  = $attacker;
                         }
 
                         $attacker_died = true;
@@ -292,28 +268,26 @@ class AttackController extends AbstractController {
                         $defenderKillpoints = 1;
 
                         if ($duel) { // *** if they were dueling when they died ***
-                            $duel_log_msg = $attacking_player->name()." has dueled {$target_player->name()} and lost at ".date("F j, Y, g:i a");
+                            $duel_log_msg = $attacker->name()." has dueled {$target->name()} and lost at ".date("F j, Y, g:i a");
                             Event::create((int)"SysMsg", (int)"SysMsg", $duel_log_msg);
-                            GameLog::sendLogOfDuel($attacking_player->name(), $target_player->name(), 0, $killpoints);	// *** Makes a loss in the duel log. ***
+                            GameLog::sendLogOfDuel($attacker->name(), $target->name(), 0, $killpoints);	// *** Makes a loss in the duel log. ***
                         }
 
-                        $target_player->addKills($defenderKillpoints); // Adds a kill for the defender
-                        $attacking_player->death();
+                        $target->addKills($defenderKillpoints); // Adds a kill for the defender
+                        $attacker->death();
 
                         if (!$simultaneousKill) {
-                            $loot = floor($gold_mod * $attacking_player->gold); //Loot for defender if he lives.
+                            $loot = floor($gold_mod * $attacker->gold); //Loot for defender if he lives.
                         }
 
-                        $target_msg = "You have killed {$attacking_player->name()} in combat and taken $loot gold.";
+                        $target_msg = "You have killed {$attacker->name()} in combat and taken $loot gold.";
 
-                        $attacker_msg = "DEATH: You've been killed by {$target_player->name()} and lost $loot gold!";
+                        $attacker_msg = "DEATH: You've been killed by {$target->name()} and lost $loot gold!";
 
-                        Event::create($attacking_player->id(), $target_player->id(), $target_msg);
-                        Event::create($target_player->id(), $attacking_player->id(), $attacker_msg);
+                        Event::create($attacker->id(), $target->id(), $target_msg);
+                        Event::create($target->id(), $attacker->id(), $attacker_msg);
                     }
                 }
-
-                // *** END MAIN ATTACK AND DUELING SECTION ***
             }
 
             if ($loot) {
@@ -324,13 +298,13 @@ class AttackController extends AbstractController {
             if ($rounds > 4) { // Evenly matched battle! Reward some ki to the attacker, even if they die
                 $rewarded_ki = 1;
 
-                $attacking_player->set_ki($attacking_player->ki + $rewarded_ki);
+                $attacker->set_ki($attacker->ki + $rewarded_ki);
             }
 
-            $attack_again = (isset($target_player) && $attacking_player->health() > 0 && $target_player->health() > 0);
+            $attack_again = (isset($target) && $attacker->health() > 0 && $target->health() > 0);
 
-            $target_ending_health = $target_player->health();
-            $target_player->save();
+            $target_ending_health = $target->health();
+            $target->save();
         }
 
         // *** Take away at least one turn even on attacks that fail. ***
@@ -338,8 +312,8 @@ class AttackController extends AbstractController {
             $turns_to_take = 1;
         }
 
-        $ending_turns = $attacking_player->changeTurns(-1*$turns_to_take);
-        $attacking_player->save();
+        $attacker->changeTurns(-1*$turns_to_take);
+        $attacker->save();
 
         return new StreamedViewResponse('Battle Status', 'attack_mod.tpl', get_defined_vars(), ['quickstat' => 'player' ]);
     }

--- a/deploy/lib/control/AttackController.php
+++ b/deploy/lib/control/AttackController.php
@@ -22,10 +22,10 @@ class AttackController extends AbstractController {
      */
     public function index() {
         $target  = RequestWrapper::getPostOrGet('target');
-        $duel    = (RequestWrapper::getPostOrGet('duel')    ? true : NULL);
-        $blaze   = (RequestWrapper::getPostOrGet('blaze')   ? true : NULL);
-        $deflect = (RequestWrapper::getPostOrGet('deflect') ? true : NULL);
-        $evade   = (RequestWrapper::getPostOrGet('evasion') ? true : NULL);
+        $duel    = (bool) RequestWrapper::getPostOrGet('duel');
+        $blaze   = (bool) RequestWrapper::getPostOrGet('blaze');
+        $deflect = (bool) RequestWrapper::getPostOrGet('deflect');
+        $evade   = (bool) RequestWrapper::getPostOrGet('evasion');
 
         // Template vars.
         $stealthed_attack = $stealth_damage = $stealth_lost =

--- a/deploy/lib/control/AttackController.php
+++ b/deploy/lib/control/AttackController.php
@@ -21,11 +21,12 @@ class AttackController extends AbstractController {
      * @return Response
      */
     public function index() {
-        $target  = RequestWrapper::getPostOrGet('target');
-        $duel    = (bool) RequestWrapper::getPostOrGet('duel');
-        $blaze   = (bool) RequestWrapper::getPostOrGet('blaze');
-        $deflect = (bool) RequestWrapper::getPostOrGet('deflect');
-        $evade   = (bool) RequestWrapper::getPostOrGet('evasion');
+        $request = RequestWrapper::$request;
+        $target  = $request->get('target');
+        $duel    = (bool) $request->get('duel');
+        $blaze   = (bool) $request->get('blaze');
+        $deflect = (bool) $request->get('deflect');
+        $evade   = (bool) $request->get('evasion');
 
         // Template vars.
         $stealthed_attack = $stealth_damage = $stealth_lost =

--- a/deploy/lib/control/AttackLegal.php
+++ b/deploy/lib/control/AttackLegal.php
@@ -172,6 +172,8 @@ class AttackLegal {
             $this->error = 'You can not attack an inactive ninja.';
         } else if ($attacker->active == 0) {
             $this->error = 'You cannot attack when your ninja is retired/inactive.';
+        } else if ($attacker->health() < 1) {
+            $this->error = 'You are dead and must revive.';
         } else if ($target->health() < 1) {
             $this->error = "They're already dead.";
         } else if ($target->hasStatus(STEALTH) && !$this->params['ignores_stealth']) {

--- a/deploy/lib/control/Combat.php
+++ b/deploy/lib/control/Combat.php
@@ -8,11 +8,14 @@ use NinjaWars\core\data\Player;
 use NinjaWars\core\data\Character;
 
 class Combat {
-    const BOUNTY_MAX = 5000;
+    const BOUNTY_MAX        = 5000;
     const BOUNTY_MULTIPLIER = 1;
+    const BOUNTY_MIN        = 25;
+    const KILLPOINTS_MIN    = 1;
 
     /**
      * Take an attacker and target, and return the killpoints
+     *
      * @return int
      */
     public static function killpointsFromDueling(Player $attacker, Player $target) {
@@ -20,39 +23,42 @@ class Combat {
 
         $multiplier = max(0, min(4, ceil($power_difference/50)));
 
-        return 1+$multiplier;
+        return self::KILLPOINTS_MIN+$multiplier;
     }
 
     /**
-     * Rewards bounty if defender has some, 
-     * otherwise increments attacker bounty if power disparity
+     * Rewards bounty if defender has some, or increments attacker bounty if power disparity
+     *
      * @return string
      */
     public static function runBountyExchange(Player $user, $defender, $bounty_mod=0) {
         assert($defender instanceof Character); // 'cause can't typehint interfaces
+
         if ($defender instanceof Player && $defender->bounty > 0) {
-            $boun = $defender->bounty;
+            $bounty = $defender->bounty;
             $defender->set_bounty(0);
             $defender->save();
-            $user->set_gold($user->gold + $boun);
+            $user->set_gold($user->gold + $bounty);
             $user->save();
-            return "You have received the {$boun} gold bounty on $defender's head for your deeds!";
+
+            return "You have received the $bounty gold bounty on $defender's head for your deeds!";
         } else { // Add bounty to attacker only if defender doesn't already have bounty on them.
             $disparity     = (int) floor(($user->difficulty() - $defender->difficulty()) / 10);
-            $bountyIncrease = min(25, max(0, ($disparity * static::BOUNTY_MULTIPLIER + $bounty_mod))); // Range of 25 - 0
+            $bountyIncrease = min(self::BOUNTY_MIN, max(0, ($disparity * static::BOUNTY_MULTIPLIER + $bounty_mod)));
+
             // Cap the increase.
-            if($bountyIncrease + $user->bounty > static::BOUNTY_MAX){
+            if ($bountyIncrease + $user->bounty > static::BOUNTY_MAX) {
                 $bountyIncrease = static::BOUNTY_MAX - $user->bounty;
             }
 
             if ($bountyIncrease > 0) {
-                // *** If Defender has no bounty and there was a level difference. ***
+                // If Defender has no bounty and there was a level difference
                 $user->set_bounty($user->bounty + $bountyIncrease);
                 $user->save();
 
                 return "Your victim was much weaker than you. The townsfolk are angered. A bounty of $bountyIncrease gold has been placed on your head!";
             } else {
-                return null;
+                return '';
             }
         }
     }

--- a/deploy/lib/control/EventsController.php
+++ b/deploy/lib/control/EventsController.php
@@ -49,8 +49,8 @@ class EventsController extends AbstractController {
             $params[':limit'] = $limit;
         }
 
-        return query("SELECT send_from, message, unread, date, uname AS from FROM events
-            JOIN players ON send_from = player_id WHERE send_to = :to ORDER BY date DESC
+        return query("SELECT coalesce(send_from, 0) AS send_from, message, unread, date, uname AS from FROM events
+            LEFT JOIN players ON send_from = player_id WHERE send_to = :to ORDER BY date DESC
             ".($limit ? "LIMIT :limit" : ''), $params);
     }
 

--- a/deploy/lib/control/NpcController.php
+++ b/deploy/lib/control/NpcController.php
@@ -158,7 +158,7 @@ class NpcController extends AbstractController {
         $victory          = false;
         $received_gold    = null;
         $received_items   = null;
-        $added_bounty     = null;
+        $added_bounty     = '';
         $is_rewarded      = null; // Gets items or gold.
         $statuses         = null;
         $status_classes   = null;

--- a/deploy/lib/data/GameLog.php
+++ b/deploy/lib/data/GameLog.php
@@ -81,7 +81,7 @@ class GameLog {
         //Log of Dueling information.
         $statement->bindValue(':attacker', $attacker);
         $statement->bindValue(':defender', $defender);
-        $statement->bindValue(':won', $won);
+        $statement->bindValue(':won', $won, \PDO::PARAM_BOOL);
         $statement->bindValue(':killpoints', $killpoints);
         $statement->execute();
     }

--- a/deploy/lib/data/Player.php
+++ b/deploy/lib/data/Player.php
@@ -116,6 +116,13 @@ class Player implements Character {
     }
 
     /**
+     *
+     */
+    public function __clone() {
+        $this->vo = clone $this->vo;
+    }
+
+    /**
      * @return string
      */
     public function name() {

--- a/deploy/lib/data/Player.php
+++ b/deploy/lib/data/Player.php
@@ -130,52 +130,46 @@ class Player implements Character {
 	}
 
     /**
-     * Actively pulls the latest status data from the db.
-     */
-	protected function getStatus() {
-		if ($this->id()) {
-			return (int) query_item("SELECT status FROM players WHERE player_id = :player_id", 
-				array(':player_id'=>array($this->id(), PDO::PARAM_INT)));
-		} else {
-			return null;
-        }
-	}
-
-    /**
      * Adds a defined numeric status constant to the binary string of statuses
      */
-	public function addStatus($p_status) {
-        $status = self::validStatus($p_status); // Filter it.
-        if($status !== null){
-            // Binary add to current status, doing nothing if already set, e.g. 000 | 010 = 010
-            $this->vo->status = $this->vo->status | $status;
-            if(gettype($this->vo->status) !== 'integer'){
-                throw new \Exception('invalid type for status');
+    public function addStatus($p_status) {
+        $status = self::validStatus($p_status);
+
+        if ($status && !$this->hasStatus($status)) {
+            if (gettype($this->status | $status) !== 'integer') {
+                throw new \InvalidArgumentException('invalid type for status');
             }
+
+            $this->status = ($this->status | $status);
+
             update_query('UPDATE players SET status = :status WHERE player_id = :player_id',
-                    [
-                    ':player_id'=>[$this->id(), PDO::PARAM_INT],
-                    ':status'=>$this->vo->status
-                    ]
-                );
-		}
-	}
+                [
+                    ':player_id' => [$this->id(), PDO::PARAM_INT],
+                    ':status'    => $this->status
+                ]
+            );
+        }
+    }
 
     /**
      * Remove a numeric status from the binary string of status toggles.
      */
     public function subtractStatus($p_status) {
-        $status = self::validStatus($p_status); // Filter it.
-        if ($status !== null) {
-            // Remove current status from binary representation, e.g. 111 & ~010 = 101
-            $current = $this->vo->status & ~$status;
-            $this->vo->status = $current; // Store as int.
+        $status = self::validStatus($p_status);
+
+        if ($status && $this->hasStatus($status)) {
+            if (gettype($this->status & ~$status) !== 'integer') {
+                throw new \InvalidArgumentException('invalid type for status');
+            }
+
+            $this->status = ($this->status & ~$status);
+
             update_query('UPDATE players SET status = :status WHERE player_id = :player_id',
-                    [
-                    ':player_id'=>[$this->id(), PDO::PARAM_INT],
-                    ':status'=>$this->vo->status
-                    ]
-                );
+                [
+                    ':player_id' => [$this->id(), PDO::PARAM_INT],
+                    ':status'    => $this->status
+                ]
+            );
         }
     }
 
@@ -183,11 +177,22 @@ class Player implements Character {
      * Resets the binary status info to 0/none
      */
 	public function resetStatus() {
-		$statement = DatabaseConnection::$pdo->prepare('UPDATE players SET status = 0 WHERE player_id = :player');
-		$statement->bindValue(':player', $this->id(), PDO::PARAM_INT);
-		$statement->execute();
+		$this->status = 0;
 
-		$this->vo->status = 0;
+		$statement = DatabaseConnection::$pdo->prepare('UPDATE players SET status = :status WHERE player_id = :player');
+		$statement->bindValue(':player', $this->id(), PDO::PARAM_INT);
+		$statement->bindValue(':status', $this->status, PDO::PARAM_INT);
+		$statement->execute();
+	}
+
+	public function hasStatus($p_status) {
+		$status = self::validStatus($p_status);
+
+		if ($status) {
+			return (bool)($this->status & $status);
+		} else {
+			return false;
+		}
 	}
 
     /**
@@ -230,7 +235,7 @@ class Player implements Character {
 			return (int) $str;
 		}
 	}
-	
+
 	public function setStrength($str){
 		if($str < 0){
 			throw new \InvalidArgumentException('Strength cannot be set as a negative.');
@@ -299,19 +304,11 @@ class Player implements Character {
 		return $this->vo->bounty = $bounty;
 	}
 
-	public function hasStatus($p_status) {
-		$status = self::validStatus($p_status);
-		if ($status) {
-			return (bool)($this->getStatus()&$status);
-		} else {
-			return false;
-		}
-	}
-
 	/**
 	 * Checks whether the character is still active.
+     *
      * @return boolean
-	**/
+	 */
 	public function isActive() {
 		return (bool) $this->vo->active;
 	}

--- a/deploy/templates/attack_mod.tpl
+++ b/deploy/templates/attack_mod.tpl
@@ -12,117 +12,12 @@
 		{if $attack_error}
 		<div class='ninja-error centered'>{$attack_error}</div>
 		{else}
-
-			{if $stealthed_attack}
-				<div>You reveal yourself with a surprise strike from the shadows!</div>
-			{/if}
-
-			{if $stealth_damage}
-				<div>{$target->name()} has lost {$starting_target->health - $target->health} health.</div>
-			{/if}
-
-			{if $stealth_lost}
-	            You have lost your stealth.
-	        {/if}
-
-			{if $blaze}
-				Your soul blazes with fire!
-			{/if}
-
-			{if $deflect}
-				You center your body and soul before battle!
-			{/if}
-
-			{if $evade}
-				As you enter battle, you note your potential escape routes...
-			{/if}
-
-			{include file="combat-prebattle-stats.tpl" attacker=$starting_attacker target=$starting_target}
-
-			{if $blaze}
-				<div>Your attack is more powerful due to blazing!</div>
-			{/if}
-
-			{if $deflect}
-				<div>Your wounds are reduced by deflecting the attack!</div>
-			{/if}
-
-			{if $evade && $target->health gt 0}
-				<div>Realizing you are out matched, you escape with your life to fight another day!</div>
-			{/if}
-
-			{if $rounds}
-				<div>Total Rounds: {$rounds}</div>
-			{/if}
-
-            {include file="combat-final-results.tpl" starting_attacker=$starting_attacker final_attacker=$attacker starting_target=$starting_target target=$target}
-
-			{if $duel}
-				<p>You spent an extra turn dueling.</p>
-			{/if}
-
-			{if $blaze}
-				<div>You spent two extra turns to blaze with power.</div>
-			{/if}
-
-			{if $deflect}
-				<div>You spent three extra turns in order to deflect your enemy's blows.</div>
-			{/if}
-
-			{if $evade}
-				<div>You spent two extra turns preparing your escape routes.</div>
-			{/if}
-
-			{if $target->health lt 1}
-				<div>{$attacker->name()} has killed {$target->name()}!</div>
-				<div class='ninja-notice'>
-					{$target->name()} is dead, you have proven your might
-				{if $killpoints eq 2}
-					twice over
-				{elseif $killpoints gt 2}
-					{$killpoints} times over
-				{/if}
-
-				!</div>
-
-				{if $loot}
-					<div>You have taken <span class='gold-count'>{$loot} gold</span> from {$target->name()}.</div>
-				{/if}
-
-				{if $wrath}
-					<div class='wrath'>Your victory fuels your wrath, allowing you to retain some of your health.</div>
-				{/if}
-			{/if}
-
-			{if $rewarded_ki}
-				<div>Your ki lifeforce has increased.</div>
-			{/if}
-
-			{if $bounty_result}
-				{$bounty_result}
-			{/if}
-
-            {if $target->health gt 0}
-                {include file="defender_health.tpl" health=$target->health level=$target->level target_name=$target->name()}
-            {/if}
-
-            {if $attacker->health lt 1}
-			<div class='parent died'>
-				<div class='child ninja-error thick'>{$target->name()} has killed you!</div>
-			</div>
-
-                {if $loot}
-				<div>{$target->name()} has taken {$loot} gold from you.</div>
-                {/if}
-		<div class='ninja-notice thick'>
-			Go to the <a href="/shrine">Shrine</a> to return to the living.
-		</div>
-            {/if}
-		{/if}{* End of no attack error section *}
+        {include file="combat.main.tpl"}
+		{/if}
 	</div><!-- End of inset-area -->
 	<nav class='attack-nav'>
 		{if $target}
-			{if $attack_again}
+			{if $target->health gt 0 && $attacker->health gt 0}
 				<div><a href="/attack?attacked=1&amp;target={$target->id()|escape:'url'}" class='attack-again thick btn btn-primary'>Attack Again?</a></div>
 			{/if}
 				<div><a href='/player?player_id={$target->id()|escape:'url'}'><< Return to <span class='char-name'>{$target->name()|escape}'s Info</span></a></div>

--- a/deploy/templates/attack_mod.tpl
+++ b/deploy/templates/attack_mod.tpl
@@ -1,3 +1,7 @@
+{**
+ * This is the main template for combat. It holds the error case and includes
+ * the main template when there is no error
+ *}
 <section id='attack-outcome'>
 	<h1>Battle Outcome</h1>
 

--- a/deploy/templates/attack_mod.tpl
+++ b/deploy/templates/attack_mod.tpl
@@ -14,17 +14,15 @@
 		{else}
 
 			{if $stealthed_attack}
-				<div>You reveal yourself with a a surprise strike from the shadows!</div>
+				<div>You reveal yourself with a surprise strike from the shadows!</div>
 			{/if}
 
 			{if $stealth_damage}
-				<div>{$target->name()} has lost {$stealthAttackDamage} health.</div>
+				<div>{$target->name()} has lost {$starting_target->health - $target->health} health.</div>
 			{/if}
 
 			{if $stealth_lost}
-
 	            You have lost your stealth.
-
 	        {/if}
 
 			{if $blaze}
@@ -39,9 +37,7 @@
 				As you enter battle, you note your potential escape routes...
 			{/if}
 
-			{if $pre_battle_stats}
-				{include file="combat-prebattle-stats.tpl" attacker_name=$attacker->name() attacker_str=$pbs_attacker_str attacker_hp=$pbs_attacker_hp target_name=$target->name() target_str=$pbs_target_str target_hp=$pbs_target_hp}
-			{/if}
+			{include file="combat-prebattle-stats.tpl" attacker=$starting_attacker target=$starting_target}
 
 			{if $blaze}
 				<div>Your attack is more powerful due to blazing!</div>
@@ -51,18 +47,15 @@
 				<div>Your wounds are reduced by deflecting the attack!</div>
 			{/if}
 
-			{if $evade && $total_attacker_damage < $target->health}
+			{if $evade && $target->health gt 0}
 				<div>Realizing you are out matched, you escape with your life to fight another day!</div>
 			{/if}
-
 
 			{if $rounds}
 				<div>Total Rounds: {$rounds}</div>
 			{/if}
 
-			{if $combat_final_results}
-				{include file="combat-final-results.tpl" attacker=$attacker target=$target}
-			{/if}
+            {include file="combat-final-results.tpl" starting_attacker=$starting_attacker final_attacker=$attacker starting_target=$starting_target target=$target}
 
 			{if $duel}
 				<p>You spent an extra turn dueling.</p>
@@ -80,26 +73,25 @@
 				<div>You spent two extra turns preparing your escape routes.</div>
 			{/if}
 
-			{if $killed_target}
+			{if $target->health lt 1}
 				<div>{$attacker->name()} has killed {$target->name()}!</div>
 				<div class='ninja-notice'>
 					{$target->name()} is dead, you have proven your might
-				{if $killpoints == 2}
+				{if $killpoints eq 2}
 					twice over
-				{elseif $killpoints > 2}
+				{elseif $killpoints gt 2}
 					{$killpoints} times over
 				{/if}
 
 				!</div>
 
-				{if !$simultaneousKill && $loot}
+				{if $loot}
 					<div>You have taken <span class='gold-count'>{$loot} gold</span> from {$target->name()}.</div>
 				{/if}
 
-				{if $wrath_regain}
+				{if $wrath}
 					<div class='wrath'>Your victory fuels your wrath, allowing you to retain some of your health.</div>
 				{/if}
-
 			{/if}
 
 			{if $rewarded_ki}
@@ -110,16 +102,16 @@
 				{$bounty_result}
 			{/if}
 
-            {if $target->health()}
+            {if $target->health gt 0}
                 {include file="defender_health.tpl" health=$target->health level=$target->level target_name=$target->name()}
             {/if}
 
-            {if $attacker_died}
+            {if $attacker->health lt 1}
 			<div class='parent died'>
 				<div class='child ninja-error thick'>{$target->name()} has killed you!</div>
 			</div>
 
-                {if !$simultaneousKill && $loot}
+                {if $loot}
 				<div>{$target->name()} has taken {$loot} gold from you.</div>
                 {/if}
 		<div class='ninja-notice thick'>

--- a/deploy/templates/attack_mod.tpl
+++ b/deploy/templates/attack_mod.tpl
@@ -2,9 +2,9 @@
 	<h1>Battle Outcome</h1>
 
 	<div class='padded-area'>
-        {if $target_player}
+        {if $target}
 		<div>
-			<a href="/player?player_id={$target_player->id()|escape:'url'}">{include file="gravatar.tpl" gurl=$target_player->avatarUrl()}</a>
+			<a href="/player?player_id={$target->id()|escape:'url'}">{include file="gravatar.tpl" gurl=$target->avatarUrl()}</a>
 		</div>
 		<hr>
         {/if}
@@ -18,7 +18,7 @@
 			{/if}
 
 			{if $stealth_damage}
-				<div>{$target_player->name()} has lost {$stealthAttackDamage} health.</div>
+				<div>{$target->name()} has lost {$stealthAttackDamage} health.</div>
 			{/if}
 
 			{if $stealth_lost}
@@ -40,7 +40,7 @@
 			{/if}
 
 			{if $pre_battle_stats}
-				{include file="combat-prebattle-stats.tpl" attacker_name=$attacking_player->name() attacker_str=$pbs_attacker_str attacker_hp=$pbs_attacker_hp target_name=$target_player->name() target_str=$pbs_target_str target_hp=$pbs_target_hp}
+				{include file="combat-prebattle-stats.tpl" attacker_name=$attacker->name() attacker_str=$pbs_attacker_str attacker_hp=$pbs_attacker_hp target_name=$target->name() target_str=$pbs_target_str target_hp=$pbs_target_hp}
 			{/if}
 
 			{if $blaze}
@@ -51,7 +51,7 @@
 				<div>Your wounds are reduced by deflecting the attack!</div>
 			{/if}
 
-			{if $evade && $total_attacker_damage < $target_health}
+			{if $evade && $total_attacker_damage < $target->health}
 				<div>Realizing you are out matched, you escape with your life to fight another day!</div>
 			{/if}
 
@@ -61,7 +61,7 @@
 			{/if}
 
 			{if $combat_final_results}
-				{include file="combat-final-results.tpl"}
+				{include file="combat-final-results.tpl" attacker=$attacker target=$target}
 			{/if}
 
 			{if $duel}
@@ -81,9 +81,9 @@
 			{/if}
 
 			{if $killed_target}
-				<div>{$attacking_player->name()} has killed {$target_player->name()}!</div>
+				<div>{$attacker->name()} has killed {$target->name()}!</div>
 				<div class='ninja-notice'>
-					{$target_player->name()} is dead, you have proven your might
+					{$target->name()} is dead, you have proven your might
 				{if $killpoints == 2}
 					twice over
 				{elseif $killpoints > 2}
@@ -93,7 +93,7 @@
 				!</div>
 
 				{if !$simultaneousKill && $loot}
-					<div>You have taken <span class='gold-count'>{$loot} gold</span> from {$target_player->name()}.</div>
+					<div>You have taken <span class='gold-count'>{$loot} gold</span> from {$target->name()}.</div>
 				{/if}
 
 				{if $wrath_regain}
@@ -110,17 +110,17 @@
 				{$bounty_result}
 			{/if}
 
-            {if $target_player->health()}
-                {include file="defender_health.tpl" health=$target_player->health() level=$target_player->level target_name=$target_player->name()}
+            {if $target->health()}
+                {include file="defender_health.tpl" health=$target->health level=$target->level target_name=$target->name()}
             {/if}
 
             {if $attacker_died}
 			<div class='parent died'>
-				<div class='child ninja-error thick'>{$target_player->name()} has killed you!</div>
+				<div class='child ninja-error thick'>{$target->name()} has killed you!</div>
 			</div>
 
                 {if !$simultaneousKill && $loot}
-				<div>{$target_player->name()} has taken {$loot} gold from you.</div>
+				<div>{$target->name()} has taken {$loot} gold from you.</div>
                 {/if}
 		<div class='ninja-notice thick'>
 			Go to the <a href="/shrine">Shrine</a> to return to the living.
@@ -129,11 +129,11 @@
 		{/if}{* End of no attack error section *}
 	</div><!-- End of inset-area -->
 	<nav class='attack-nav'>
-		{if $target_player}
+		{if $target}
 			{if $attack_again}
-				<div><a href="/attack?attacked=1&amp;target={$target_player->id()|escape:'url'}" class='attack-again thick btn btn-primary'>Attack Again?</a></div>
+				<div><a href="/attack?attacked=1&amp;target={$target->id()|escape:'url'}" class='attack-again thick btn btn-primary'>Attack Again?</a></div>
 			{/if}
-				<div><a href='/player?player_id={$target_player->id()|escape:'url'}'><< Return to <span class='char-name'>{$target_player->name()|escape}'s Info</span></a></div>
+				<div><a href='/player?player_id={$target->id()|escape:'url'}'><< Return to <span class='char-name'>{$target->name()|escape}'s Info</span></a></div>
 		{/if}
 		<a href='/enemies' class='return-to-location'>Return to the Fight</a>
 	</nav>

--- a/deploy/templates/combat-final-results.tpl
+++ b/deploy/templates/combat-final-results.tpl
@@ -10,7 +10,7 @@
 
       <tr>
         <td>{$attacker->name()|escape}</td>
-        <td style="text-align: center;">{$total_attacker_damage|escape}</td>
+        <td style="text-align: center;">{$starting_attacker->health - $attacker->health|escape}</td>
         <td>
 {if $attacker->health lt 100} {* Makes your health red if you go below 100 hitpoints. *}
           <span style="color:red;font-weight:bold;">
@@ -24,7 +24,7 @@
       </tr>
       <tr>
         <td>{$target->name()|escape}</td>
-        <td style="text-align: center;">{$total_target_damage|escape}</td>
+        <td style="text-align: center;">{$starting_target->health - $target->health|escape}</td>
         <td>{$target->health}</td>
       </tr>
     </table>

--- a/deploy/templates/combat-final-results.tpl
+++ b/deploy/templates/combat-final-results.tpl
@@ -9,23 +9,23 @@
       </tr>
 
       <tr>
-        <td>{$attacking_player->name()|escape}</td>
+        <td>{$attacker->name()|escape}</td>
         <td style="text-align: center;">{$total_attacker_damage|escape}</td>
         <td>
-{if $finalizedHealth lt 100} {* Makes your health red if you go below 100 hitpoints. *}
+{if $attacker->health lt 100} {* Makes your health red if you go below 100 hitpoints. *}
           <span style="color:red;font-weight:bold;">
 {else} {* Normal text color for health. *}
           <span style="color:brown;font-weight:normal;">
 {/if}
 
-            {$finalizedHealth|escape}
+            {$attacker->health|escape}
           </span>
         </td>
       </tr>
       <tr>
-        <td>{$target_player->name()|escape}</td>
+        <td>{$target->name()|escape}</td>
         <td style="text-align: center;">{$total_target_damage|escape}</td>
-        <td>{math equation="x - y" x=$target_health y=$total_attacker_damage}</td>
+        <td>{$target->health}</td>
       </tr>
     </table>
     <hr>

--- a/deploy/templates/combat-final-results.tpl
+++ b/deploy/templates/combat-final-results.tpl
@@ -1,3 +1,6 @@
+{**
+ * Shows a table of attacker/target stats for use after combat
+ *}
     <table style="border: 0;">
       <tr>
         <th colspan="3">Results of the Attack</th>

--- a/deploy/templates/combat-prebattle-stats.tpl
+++ b/deploy/templates/combat-prebattle-stats.tpl
@@ -8,14 +8,14 @@
         <td>HP</td>
       </tr>
       <tr>
-        <td>{$attacker_name|escape}</td>
-        <td>{$attacker_str|escape}</td>
-        <td style="color:brown;font-weight:normal;">{$attacker_hp|escape}</td>
+        <td>{$attacker->name()|escape}</td>
+        <td>{$attacker->getStrength()|escape}</td>
+        <td style="color:brown;font-weight:normal;">{$attacker->health|escape}</td>
       </tr>
       <tr>
-        <td>{$target_name|escape}</td>
-        <td>{$target_str|escape}</td>
-        <td>{$target_hp|escape}</td>
+        <td>{$target->name()|escape}</td>
+        <td>{$target->getStrength()|escape}</td>
+        <td>{$target->health|escape}</td>
       </tr>
     </table>
     <hr>

--- a/deploy/templates/combat-prebattle-stats.tpl
+++ b/deploy/templates/combat-prebattle-stats.tpl
@@ -1,3 +1,6 @@
+{**
+ * Shows a table of attacker/target stats for use before combat
+ *}
     <table border="0">
       <tr>
         <th colspan="3">Before the Attack</th>

--- a/deploy/templates/combat.main.tpl
+++ b/deploy/templates/combat.main.tpl
@@ -1,3 +1,6 @@
+{**
+ * This template renders the result of a successful combat request
+ *}
 {if $stealthed_attack}
 <div>You reveal yourself with a surprise strike from the shadows!</div>
 {/if}

--- a/deploy/templates/combat.main.tpl
+++ b/deploy/templates/combat.main.tpl
@@ -68,7 +68,7 @@ As you enter battle, you note your potential escape routes...
 !</div>
 
     {if $loot}
-<div>You have taken <span class='gold-count'>{$loot} gold</span> from {$target->name()}.</div>
+<div>You have taken <span class='gold-count'>{$loot|number_format:0|escape} gold</span> from {$target->name()}.</div>
     {/if}
 
     {if $wrath}
@@ -90,13 +90,19 @@ As you enter battle, you note your potential escape routes...
 
 {if $attacker->health lt 1}
 <div class='parent died'>
-<div class='child ninja-error thick'>{$target->name()} has killed you!</div>
+    <div class='child ninja-error thick'>
+        {$target->name()} has killed you!
+    </div>
 </div>
 
     {if $loot}
-<div>{$target->name()} has taken {$loot} gold from you.</div>
+<div class='parent'>
+    <div class='child ninja-notice'>
+        {$target->name()} has <strong>taken</strong> <span class='gold-count'>{$loot|number_format:0|escape} gold</span> from you!
+    </div>
+</div>
     {/if}
 <div class='ninja-notice thick'>
-Go to the <a href="/shrine">Shrine</a> to return to the living.
+    Go to the <a href="/shrine">Shrine</a> to return to the living.
 </div>
 {/if}

--- a/deploy/templates/combat.main.tpl
+++ b/deploy/templates/combat.main.tpl
@@ -1,0 +1,102 @@
+{if $stealthed_attack}
+<div>You reveal yourself with a surprise strike from the shadows!</div>
+{/if}
+
+{if $stealth_damage}
+<div>{$target->name()} has lost {$starting_target->health - $target->health} health.</div>
+{/if}
+
+{if $stealth_lost}
+You have lost your stealth.
+{/if}
+
+{if $options.blaze}
+Your soul blazes with fire!
+{/if}
+
+{if $options.deflect}
+You center your body and soul before battle!
+{/if}
+
+{if $options.evade}
+As you enter battle, you note your potential escape routes...
+{/if}
+
+{include file="combat-prebattle-stats.tpl" attacker=$starting_attacker target=$starting_target}
+
+{if $options.blaze}
+<div>Your attack is more powerful due to blazing!</div>
+{/if}
+
+{if $options.deflect}
+<div>Your wounds are reduced by deflecting the attack!</div>
+{/if}
+
+{if $options.evade && $target->health gt 0}
+<div>Realizing you are out matched, you escape with your life to fight another day!</div>
+{/if}
+
+<div>Total Rounds: {$rounds}</div>
+
+{include file="combat-final-results.tpl" starting_attacker=$starting_attacker final_attacker=$attacker starting_target=$starting_target target=$target}
+
+{if $options.duel}
+<p>You spent an extra turn dueling.</p>
+{/if}
+
+{if $options.blaze}
+<div>You spent two extra turns to blaze with power.</div>
+{/if}
+
+{if $options.deflect}
+<div>You spent three extra turns in order to deflect your enemy's blows.</div>
+{/if}
+
+{if $options.evade}
+<div>You spent two extra turns preparing your escape routes.</div>
+{/if}
+
+{if $target->health lt 1}
+<div>{$attacker->name()} has killed {$target->name()}!</div>
+<div class='ninja-notice'>
+    {$target->name()} is dead, you have proven your might
+    {if $killpoints eq 2}
+    twice over
+    {elseif $killpoints gt 2}
+    {$killpoints} times over
+    {/if}
+!</div>
+
+    {if $loot}
+<div>You have taken <span class='gold-count'>{$loot} gold</span> from {$target->name()}.</div>
+    {/if}
+
+    {if $wrath}
+<div class='wrath'>Your victory fuels your wrath, allowing you to retain some of your health.</div>
+    {/if}
+{/if}
+
+{if $rewarded_ki}
+<div>Your ki lifeforce has increased.</div>
+{/if}
+
+{if $bounty_result}
+{$bounty_result}
+{/if}
+
+{if $target->health gt 0}
+{include file="defender_health.tpl" health=$target->health level=$target->level target_name=$target->name()}
+{/if}
+
+{if $attacker->health lt 1}
+<div class='parent died'>
+<div class='child ninja-error thick'>{$target->name()} has killed you!</div>
+</div>
+
+    {if $loot}
+<div>{$target->name()} has taken {$loot} gold from you.</div>
+    {/if}
+<div class='ninja-notice thick'>
+Go to the <a href="/shrine">Shrine</a> to return to the living.
+</div>
+{/if}

--- a/deploy/templates/event.single.tpl
+++ b/deploy/templates/event.single.tpl
@@ -1,5 +1,9 @@
     <dt class='user {if isset($last_user_event) && $last_user_event eq $event.send_from}repeated{/if}'>
+{if $event.send_from gt 0}
     	<a target='main' class='event-sender' href='/player?player_id={$event.send_from|escape:'url'}'>{$event.from|escape}</a>
+{else}
+        <strong>???</strong>
+{/if}
     </dt>
     <dd class='user-message{if $event.unread} message-unread{/if}'>
     	{$event.message|escape|replace_urls|markdown}<time class="event-time timeago" datetime="{$event.date}" title="{$event.date}">{$event.date}</time>

--- a/deploy/templates/event.single.tpl
+++ b/deploy/templates/event.single.tpl
@@ -2,7 +2,7 @@
 {if $event.send_from gt 0}
     	<a target='main' class='event-sender' href='/player?player_id={$event.send_from|escape:'url'}'>{$event.from|escape}</a>
 {else}
-        <strong>???</strong>
+        <strong class='generic-event'><i class="fa fa-star" aria-hidden="true"></i></strong>
 {/if}
     </dt>
     <dd class='user-message{if $event.unread} message-unread{/if}'>

--- a/deploy/tests/integration/controller/AttackControllerTest.php
+++ b/deploy/tests/integration/controller/AttackControllerTest.php
@@ -29,8 +29,10 @@ class AttackControllerTest extends PHPUnit_Framework_TestCase {
     }
 
     public function testAttackWithoutArgs() {
-        $response = $this->controller->index();
+        $request = Request::create('/attack', 'GET', []);
+        RequestWrapper::inject($request);
 
+        $response = $this->controller->index();
         $this->assertInstanceOf(StreamedViewResponse::class, $response);
     }
 

--- a/deploy/tests/integration/controller/AttackControllerTest.php
+++ b/deploy/tests/integration/controller/AttackControllerTest.php
@@ -59,4 +59,28 @@ class AttackControllerTest extends PHPUnit_Framework_TestCase {
 
         $this->assertInstanceOf(StreamedViewResponse::class, $response);
     }
+
+    public function testAttackWhenDead() {
+        $attacker = Player::find(SessionFactory::getSession()->get('player_id'));
+        $attacker->death();
+        $attacker->save();
+
+        $char_id_2 = TestAccountCreateAndDestroy::char_id_2();
+
+        $params = [
+            'target' => $char_id_2,
+        ];
+
+        $request = Request::create('/attack', 'GET', $params);
+        RequestWrapper::inject($request);
+        $response = $this->controller->index();
+
+        $this->assertInstanceOf(StreamedViewResponse::class, $response);
+
+        $reflection = new \ReflectionProperty(get_class($response), 'data');
+        $reflection->setAccessible(true);
+        $response_data = $reflection->getValue($response);
+
+        $this->assertNotEmpty($response_data['error']);
+    }
 }

--- a/deploy/tests/integration/controller/CombatTest.php
+++ b/deploy/tests/integration/controller/CombatTest.php
@@ -42,7 +42,7 @@ class CombatTest extends \PHPUnit_Framework_TestCase {
 
         $bounty_mess = Combat::runBountyExchange($pc, $def, $bounty_mod);
         // Equal pcs, no bounty message
-        $this->assertEquals(null, $bounty_mess);
+        $this->assertEquals('', $bounty_mess);
     }
 
     public function testBountyExchangeWithSomeBountyOnDefender(){
@@ -60,7 +60,7 @@ class CombatTest extends \PHPUnit_Framework_TestCase {
 
         $bounty_mess = Combat::runBountyExchange($pc, $def, $bounty_mod);
         // Equal pcs, no bounty message
-        $this->assertNotEquals(null, $bounty_mess);
+        $this->assertNotEquals('', $bounty_mess);
     }
 
     public function testBountyExchangeWithInequalPcs(){
@@ -77,7 +77,7 @@ class CombatTest extends \PHPUnit_Framework_TestCase {
 
         $bounty_mess = Combat::runBountyExchange($pc, $def, $bounty_mod);
         // With a high difficulty pc, some bounty should be put on.
-        $this->assertNotEquals(null, $bounty_mess);
+        $this->assertNotEquals('', $bounty_mess);
         //$this->assertGreaterThan(0, $pc->bounty);
     }
 
@@ -90,7 +90,7 @@ class CombatTest extends \PHPUnit_Framework_TestCase {
 
         $bounty_mess = Combat::runBountyExchange($pc, $npc, $npc->bountyMod());
         // With a high powered pc, some bounty should be put on by attacking a low powered npc.
-        $this->assertNotEquals(null, $bounty_mess);
+        $this->assertNotEquals('', $bounty_mess);
     }
 
     public function testBountyDoesntGrowOutOfBounds(){
@@ -103,7 +103,7 @@ class CombatTest extends \PHPUnit_Framework_TestCase {
         $def->bounty = 0;
 
         $bounty_mess = Combat::runBountyExchange($pc, $def, $bounty_mod);
-        $this->assertEquals(null, $bounty_mess);
+        $this->assertEquals('', $bounty_mess);
     }
 
 
@@ -116,6 +116,6 @@ class CombatTest extends \PHPUnit_Framework_TestCase {
 
         $bounty_mess = Combat::runBountyExchange($pc, $npc, $npc->bountyMod());
         // With a high powered pc, some bounty should be put on by attacking a low powered npc.
-        $this->assertNotEquals(null, $bounty_mess);
+        $this->assertNotEquals('', $bounty_mess);
     }
 }

--- a/deploy/www/css/style.css
+++ b/deploy/www/css/style.css
@@ -1436,6 +1436,9 @@ iframe {
   float:left; width:20%; /* adjust the width; make sure the total of both is 100% */
   min-width:160px;
 }
+#event-list .generic-event{
+	color:gray;
+}
 .chat-messages .chat-message a {
 	font-size:smaller;
 }


### PR DESCRIPTION
Combat is finally getting some attention and some simplification. This splits the game rules validation from the actual combat code, as well as the rules validation error render from the actual combat render. A couple small functions have been split out for standard combat rounds versus stealth combat rounds, and many branches and temporary variables have been removed.

Other changes include:  
1. **Removing Player->getStatus()**: It queried the DB, the VO already has status.  
2. addStatus() and subtractStatus() now check if the requested status is set before changing  
3. Added __clone() to Player to allow for creating a copy of a Player with a copy of the VO  

If this code passes muster, despite it not adding to the game, it needs to be merged in. I won't have much time this week to do too much, and this code inventory will get stale very quickly if it's not merged in. Next steps include:

1. making duel a separate command from single-attack, instead of an option  
2. removing conditionals in the view and replacing them with explicit view parts for the controller to add explicitly  
3. **Factor out combat options as Skills and Buffs**  
4. **Factor out deep inspection of Skills/Buffs and rely on Player object to know what to do**