### PR TITLE
Events: Cleanup npc death event dates, which are redundant, and make clan disband create an event too.

### DIFF
--- a/deploy/lib/control/NpcController.php
+++ b/deploy/lib/control/NpcController.php
@@ -270,8 +270,6 @@ class NpcController extends AbstractController {
             $victim = null; // No match, victim is null.
         }
 
-        $today = date("F j, Y, g:i a");  // Today var is only used for creating mails.
-
         $turn_cost      = 1;
         $health         = true;
         $combat_data    = [];
@@ -334,7 +332,7 @@ class NpcController extends AbstractController {
             if ($player->health() <= 0) { // FINAL CHECK FOR DEATH
                 $player->death();
                 $health = false;
-                Event::create((int)"SysMsg", $player->id(), "DEATH: You have been killed by a $victim on $today");
+                Event::create((int)"SysMsg", $player->id(), "DEATH: You have been killed by a $victim.");
             }
 
             // Subtract the turn cost for attacking an npc

--- a/deploy/lib/data/Clan.php
+++ b/deploy/lib/data/Clan.php
@@ -271,6 +271,8 @@ class Clan {
                 'message'   => $message,
                 'type'      => 0,
             ]);
+            // Create both an event and a message!
+            Event::create(0, $memberId, $message);
         }
 
         // Deletion of the clan_player connections should cascade from the deletion of the clan, at least ideally.


### PR DESCRIPTION
Fix #778