### PR TITLE
Player: Don't date init last_started_attack

### DIFF
--- a/deploy/lib/data/Player.php
+++ b/deploy/lib/data/Player.php
@@ -81,7 +81,7 @@ class Player implements Character {
         $this->traits              = '';
         $this->beliefs             = '';
         $this->goals               = '';
-        $this->last_started_attack = '2016-01-01';
+        $this->last_started_attack = null;
     }
 
     /**


### PR DESCRIPTION
unnecessarily, since it's a null-allowed field.