### PR TITLE
Intro: load jQuery only once ready, and improve epics.

### DIFF
--- a/deploy/templates/epics.tpl
+++ b/deploy/templates/epics.tpl
@@ -1,12 +1,5 @@
-<style>
-    {literal}
-        main#epics section {
-            max-height: 50vh;
-            overflow-y: auto
-        }
-
-    {/literal}
-</style>
+<link src='/css/epics.css' rel='stylesheet' type='text/css' />
+<script src='/js/epics.js'></script>
 <main id='epics'>
     <span style='float:left'><a href='/'><button type='button' class='btn btn-default'><i
                     class='fa fa-home'></i></button></a></span>
@@ -24,6 +17,7 @@
 
         <nav class='nav parent' id='sections-control'>
             <div class='child'>
+<a class='btn btn-info' href='#intro-section'>Intro</a>
 <a class='btn btn-info' href='#aside-section'>Aside</a>
 <a class='btn btn-info' href='#chat-section'>Chat</a>
             </div>
@@ -32,6 +26,10 @@
     </header>
 
 <div id='stories'>
+        <section id='intro-section'>
+            <h2>Intro</h2>
+            {include file="intro.tpl"}
+</section>
         <section id='aside-section'>
             <h2>Aside</h2>
             {include file="aside.tpl"}
@@ -41,7 +39,8 @@
             <h2>Chat</h2>
             {include file="mini-chat.section.tpl"}
         </section>
+
 </div>
-    <script src='/js/epics.js'></script>
+{* js script at the top to prevent breaking from templates *}
 
 </main>

--- a/deploy/www/css/epics.css
+++ b/deploy/www/css/epics.css
@@ -1,0 +1,4 @@
+main#epics section {
+    max-height: 50vh;
+    overflow-y: auto
+}

--- a/deploy/www/js/epics.js
+++ b/deploy/www/js/epics.js
@@ -1,6 +1,7 @@
 /* eslint-disable semi */
+
 /* global jQuery */
-((function epicsRender(jQuery) {
+$(function epicsRender() {
     const $ = jQuery
     $('#stories section').hide()
     $('#sections-control a').click(function showHide(e) {
@@ -8,4 +9,4 @@
         const href = $(this).attr('href')
         $(href).toggle();
     })
-})(jQuery))
+})

--- a/deploy/www/js/intro.js
+++ b/deploy/www/js/intro.js
@@ -20,7 +20,7 @@ function fadeIntro($) {
 }
 
 
-(function introManipulations($) {
+$(function introManipulations() {
     // Page css hides the faq section to avoid FOUC
     var showFaqs = false; // Set faqs hidden by default.
     var showfaqsLink = $('#show-faqs');
@@ -43,4 +43,4 @@ function fadeIntro($) {
         $(event.target).toggle();
         return false;
     });
-}($)); // End of IIFE
+}); // On ready


### PR DESCRIPTION
# Purpose of PR:

> onReady on intro.js / intro page.
-
-
-

## _Things that make review take longer:_

_(remove lines that do not apply to this PR)_

-   [ ] Changing more than 20 files (much harder to review)
-   [ ] Changing more than 5 files (a bit harder to review)
-   [ ] Changes to critical code (login, dashboard, etc)
-   [ ] No comments on changed files
-   Tests do not pass (will get pushed back)

## _Things that make review faster and easier:_

_(check box with an x where it applies)_

-   [x] I attached a screenshot of the changed part of the app working
-   [ ] I added tests
-   [ ] This feature is requested specifically by a player
-   [ ] This will fix a bug

## _Attached Screenshot of my change:_

![image](https://user-images.githubusercontent.com/23353/139747176-ac10b02e-236d-4c1a-8b84-34222215ac72.png)

## _Preview results in my branch at the url:_

-   https://localhost:8765/intro
- -   https://localhost:8765/epics
