### PR TITLE
Improve feedback of work and attacking npcs with animation of outcome.

### DIFF
--- a/deploy/templates/npc.abstract.tpl
+++ b/deploy/templates/npc.abstract.tpl
@@ -108,7 +108,7 @@ article#fight nav{
 	{/if}
 	{if $survive_fight}
 		{if $is_weaker}<p>The {if $is_villager}villager{/if}{if !$is_villager}{$race|escape}{/if} is no match for you!</p>{/if}
-		{if $kill_npc}<p class='ninja-notice'>You kill the {$display_name|escape}!</p>
+		{if $kill_npc}<p class='ninja-notice fade-in'>You kill the {$display_name|escape}!</p>
 			{if $added_bounty}
 			<div class='bounty-notice'>{if $is_villager}<p>You have slain a member of the village!</p>{/if} <em class='money'>{$added_bounty}</div>
 			{/if}
@@ -133,7 +133,7 @@ article#fight nav{
 
 
 	{else}
-		<div class='ninja-error'>The {$display_name|escape} has killed you!</div>
+		<div class='ninja-error fade-in-flash'>The {$display_name|escape} has killed you!</div>
 	{/if}
 
 	</section><!-- end of .npc-fight -->

--- a/deploy/templates/work.tpl
+++ b/deploy/templates/work.tpl
@@ -21,40 +21,40 @@
 <div class="description">
     <p>
         On your way back from the fields, you pass by a few young children
-        chasing grasshoppers in the tall grass.</p>
+        chasing grasshoppers.</p>
     <p>You see a <a href='/npc/attack/viper' class='npc'>Viper</a> in the tall grass.</p>
 
     <p>The samurai foreman hands you a small pouch of gold as he says
     <em class='speech'>Care to put a little more work in? I'll pay the same rate.</em></p>
 
-    <p class='ninja-notice'>You have worked for {$worked} {if $worked eq 1}turn{else}turns{/if} and earned 石{$earned_gold}.</p>
+    <p class='ninja-notice slide-in-from-left' style='font-size:larger'>You have worked for {$worked} {if $worked eq 1}turn{else}turns{/if} and
+earned 石{$earned_gold}.</p>
 </div>
 {/if}
 
 <section class='glassbox'>
 
-<p>You can earn money by working in the village fields. Field work will exchange turns for gold. <span style='color:turquoise;'>1 Turn</span> = <span class='gold'>石{$work_multiplier}</span>.</p>
-
 {if $authenticated}
-<form id="work" action="/work/request_work" method="post" name="work">
-  <div style="width:40%;margin:3rem auto;">
-    <span class="input-group">
-        <span class='input-group-addon'>Work for</span>
-        <input id="worked" type="number" size="3" maxlength="3" min=1 max=999 name="worked" class="textField form-control">
-        <span class='input-group-btn'>
-            <input id="workButton" class="formButton btn btn-primary" type="submit" value="Turns" name="workButton">
+    <div style="width:40%;margin:3rem auto;">
+    <form id="work" action="/work/request_work" method="post" name="work">
+        <span class="input-group">
+            <span class='input-group-addon'>Work for</span>
+            <input id="worked" type="number" size="3" maxlength="3" min=1 max=999 name="worked" class="textField form-control">
+            <span class='input-group-btn'>
+                <input id="workButton" class="formButton btn btn-primary" type="submit" value="Turns" name="workButton">
+            </span>
         </span>
-    </span>
-  </div>
-</form>
+    </form>
+
+    <small>Work the fields for the daimyo to earn your keep. <span
+            style='color:turquoise;'>1 Turn</span> = <span class='gold'>石{$work_multiplier}</span>.</small>
+</div>
 <p class='gold-count'>
   Current gold: 石{$gold_display|escape}
 <p>
 <p>
     Current turns: <span class='turns-count'>{($char)? $char->turns : ''}</span>
 </p>
-
-
 {else}
 <p>
 To earn pay for your work you must first <a href="/signup">become a citizen of this village.</a>


### PR DESCRIPTION
# Purpose of PR:

> --- Improve the work page so that each time you reload it doesn't just flash the same message, it animates so that you know a new work request went through.  Same with attacking npcs page.
-
-
-

![image](https://user-images.githubusercontent.com/23353/147601285-129f0cdf-98e9-47b1-8ad0-fe83fdf30443.png)

![image](https://user-images.githubusercontent.com/23353/147601235-a1c71489-d367-43c9-9496-e297741f6b7d.png)



## _Things that make review take longer:_

_(remove lines that do not apply to this PR)_

-   [x] Changing more than 20 files (much harder to review)
-   [x] Changing more than 5 files (a bit harder to review)
-   [x] Changes to critical code (login, dashboard, etc)
-   [x] No comments on changed files
-   Tests do not pass (will get pushed back)

## _Things that make review faster and easier:_

_(check box with an x where it applies)_

-   [ ] I attached a screenshot of the changed part of the app working
-   [ ] I added tests
-   [ ] This feature is requested specifically by a player
-   [ ] This will fix a bug

## _Attached Screenshot of my change:_

## _Preview results in my branch at the url:_

-   https://localhost:8765/someUrlHere
