### PR TITLE
fix: guard against logged out searching through enemies error,

### DIFF
--- a/deploy/lib/control/ConsiderController.php
+++ b/deploy/lib/control/ConsiderController.php
@@ -38,7 +38,7 @@ class ConsiderController extends AbstractController {
     public function search(Container $p_dependencies): StreamedViewResponse {
         $enemy_match = RequestWrapper::getPostOrGet('enemy_match');
         $current_player = $p_dependencies['current_player'];
-        $found_enemies = ($enemy_match ? Enemies::search($current_player, $enemy_match) : []);
+        $found_enemies = ($enemy_match && $current_player ? Enemies::search($current_player, $enemy_match) : []);
         $parts = $this->configure();
 
         // Add some additional parts


### PR DESCRIPTION
just pretend no results when there is no logged in current player.

# Purpose of PR:

> ---
-
-
-

## _Attached Screenshot of my change:_

## _Things that make review take longer:_

_(remove lines that do not apply to this PR)_

-   [x] Changing more than 20 files (much harder to review)
-   [x] Changing more than 5 files (a bit harder to review)
-   [x] Changes to critical code (login, dashboard, etc)
-   [x] No comments on changed files
-   Tests do not pass (will get pushed back)

## _Things that make review faster and easier:_

_(check box with an x where it applies)_

-   [ ] I attached a screenshot of the changed part of the app working
-   [ ] I added tests
-   [ ] This feature is requested specifically by a player
-   [ ] This will fix a bug

## _Preview results in my branch at the url:_

-   https://localhost:8765/someUrlHere
